### PR TITLE
Cleanup old docker images

### DIFF
--- a/.github/workflows/cleanup_docker.yaml
+++ b/.github/workflows/cleanup_docker.yaml
@@ -1,0 +1,23 @@
+name: Cleanup old docker containers
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"  # run every day at midnight, utc
+
+jobs:
+  delete-package-versions:
+    name: Delete PR images older than 2 weeks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: snok/container-retention-policy@v3.0.0
+        with:
+          account: openmethane
+          # Token with delete:packages scope
+          # TODO: Migrate to an org GitHub App with the same permissions
+          token: ${{ secrets.PAT }}
+          image-names: openmethane
+          image-tags: "pr-* !latest"
+          tag-selection: both  # select both tagged and untagged package versions
+          cut-off: 2w
+          dry-run: true


### PR DESCRIPTION
## Description

Cleans up untagged images and images tagged `pr-*` that are older than 2 weeks old from the container registry. This runs daily at 00:00 UTC.

Uses [https://github.com/snok/container-retention-policy]()

This currently runs in dry-run mode to verify that it works. A follow-up PR will be required to disable dry-run mode when it is verified to work.

I'll do the same with the setup-wrf repo which currently has 150 images that will be cleaned up. An alternative would be to run this action from the om-infra repo and do it all from one place.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
<!--- Below to be added back once we have a changelog --> 
<!--- - [ ] Changelog item added to `changelog/`) -->

## Notes

@aethr This uses a personal access token of mine with the `delete:packages` scope. One day it might be better to use an org Github app to provide the same credentials https://github.com/snok/container-retention-policy?tab=readme-ov-file#github-app-tokens, but that is likely quite a faff and something I can't do.


This can also be run locally using:
```
docker run \             
  --rm \
  -e RUST_LOG=container_retention_policy=info \
  ghcr.io/snok/container-retention-policy:v3.0.0  \
  --dry-run true \
  --account openmethane \
  --token $GITHUB_TOKEN_DOCKER \
  --cut-off 1w \
  --image-names "openmethane" \
  --image-tags 'pr-* !latest' \
  --shas-to-skip ""
```

