### PR TITLE
correcting test_grad_cmaq sensitivities by top pressure

### DIFF
--- a/tests/integration/fourdvar/test_grad_cmaq.py
+++ b/tests/integration/fourdvar/test_grad_cmaq.py
@@ -74,7 +74,7 @@ def _run_grad_cmaq():
         rhoj = ncf.get_variable(met_file, "DENSA_J")[:, : lay_thick.size, ...]
         top_pressure = ncf.get_attr(met_file, "VGTOP")
         # we need to correct by the top pressure. The DENSA_J variable is in kg/m**2 so we need to subtract off the mass associated with the top level
-        rhoj = rhoj - top_pressure-grav
+        rhoj = rhoj - top_pressure/grav
         xcell = ncf.get_attr(met_file, "XCELL")
         ycell = ncf.get_attr(met_file, "YCELL")
         cell_area = float(xcell * ycell)


### PR DESCRIPTION
## Description
the native CMAQ model has inputs of mole/gridcell/s while the
sensitivities are in cost-function/ppm/s, this requires a conversion
including layer mass. This was calculated as the fractional sigma
thickness times column air mass. This disregarded the air excluded
above the top layer. This attempts to correct this at least in the
CMAQ gradient test. I am creating the PR now so it can generate a
docker container to test. If the test passes I will test whether the
same change improves test_grad_finite_diff. I will update the PR then.
## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`)

## Notes