### PR TITLE
fix: update to latest cdsapi

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -78,13 +78,13 @@ crt = ["awscrt (==0.21.5)"]
 
 [[package]]
 name = "cads-api-client"
-version = "1.0.3"
+version = "1.3.3"
 description = "CADS API Python client"
 optional = false
 python-versions = "*"
 files = [
-    {file = "cads_api_client-1.0.3-py3-none-any.whl", hash = "sha256:fff4e4501692ff25a1ef15896f93630ec444fd338473f710def87708a1cf0adf"},
-    {file = "cads_api_client-1.0.3.tar.gz", hash = "sha256:5b10f08ea559237e49ae1c742fea9aef48280cb786f346f6cacda224b9c204e0"},
+    {file = "cads_api_client-1.3.3-py3-none-any.whl", hash = "sha256:698ce555b4f28df0bb70a8012d666efad05b3d3839ae217f5931a53e2e1b137f"},
+    {file = "cads_api_client-1.3.3.tar.gz", hash = "sha256:f8fec3e74355bd540668bf8ed33f5cca89a50df77c5859dd0f9b2893fab1384e"},
 ]
 
 [package.dependencies]
@@ -95,17 +95,17 @@ typing-extensions = "*"
 
 [[package]]
 name = "cdsapi"
-version = "0.7.0"
+version = "0.7.3"
 description = "Climate Data Store API"
 optional = false
 python-versions = "*"
 files = [
-    {file = "cdsapi-0.7.0-py2.py3-none-any.whl", hash = "sha256:b78d871c13862095476986904e7d7224c2480a6670e1bfd46718e095eaaf9b19"},
-    {file = "cdsapi-0.7.0.tar.gz", hash = "sha256:293ba622f25a15c29c435763d0bbeff4c44d1ee71bc7df965e9d191160d39d59"},
+    {file = "cdsapi-0.7.3-py2.py3-none-any.whl", hash = "sha256:3bf432783e6ff0b47b0b33466c6e05e7ddad52fda5f05bf269596f5be30d623b"},
+    {file = "cdsapi-0.7.3.tar.gz", hash = "sha256:883a1376ca495457eb55fd548dbbb6f5b64f2e4c880b3586dd37ba9041e51c82"},
 ]
 
 [package.dependencies]
-cads-api-client = ">=0.9.2"
+cads-api-client = ">=1.3.2"
 requests = ">=2.5.0"
 tqdm = "*"
 
@@ -1142,4 +1142,4 @@ xarray = ">=2023.12.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "6ac2d7a72db93f83e29495fc9f2a01bb4026039123be8b180fa105aef61c245d"
+content-hash = "66b17c5fb0d3bb209bcbbdc3c710084673bf8ec76dbe4f0330501f898fd6f7c8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ environs = "^11.0.0"
 xarray = "^2024.5.0"
 xarray-datatree = "^0.0.14"
 click = "^8.1.7"
-cdsapi = "^0.7.0"
+cdsapi = "^0.7.3"
 attrs = "^23.2.0"
 boto3 = "^1.35.11"
 


### PR DESCRIPTION
## Description

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`)

## Notes

This should fix the warning "You are using a deprecated API endpoint. If you are using cdsapi, please upgrade to the latest version." and hopefully also this error:
```
2024-09-23T13:42:48.444000: Traceback (most recent call last):
2024-09-23T13:42:48.444000:   File "/opt/project/scripts/cmaq_preprocess/download_cams_input.py", line 83, in <module>
2024-09-23T13:42:48.444000:     download_cams_input()
2024-09-23T13:42:48.444000:   File "/opt/venv/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
2024-09-23T13:42:48.444000:     return self.main(*args, **kwargs)
2024-09-23T13:42:48.444000:            ^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-09-23T13:42:48.444000:   File "/opt/venv/lib/python3.11/site-packages/click/core.py", line 1078, in main
2024-09-23T13:42:48.444000:     rv = self.invoke(ctx)
2024-09-23T13:42:48.444000:          ^^^^^^^^^^^^^^^^
2024-09-23T13:42:48.444000:   File "/opt/venv/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
2024-09-23T13:42:48.445000:     return ctx.invoke(self.callback, **ctx.params)
2024-09-23T13:42:48.445000:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-09-23T13:42:48.445000:   File "/opt/venv/lib/python3.11/site-packages/click/core.py", line 783, in invoke
2024-09-23T13:42:48.445000:     return __callback(*args, **kwargs)
2024-09-23T13:42:48.445000:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-09-23T13:42:48.445000:   File "/opt/project/scripts/cmaq_preprocess/download_cams_input.py", line 63, in download_cams_input
2024-09-23T13:42:48.445000:     c.retrieve(
2024-09-23T13:42:48.445000:   File "/opt/venv/lib/python3.11/site-packages/cads_api_client/legacy_api_client.py", line 149, in retrieve
2024-09-23T13:42:48.445000:     result = self.logging_decorator(self.client.submit_and_wait_on_result)(
2024-09-23T13:42:48.445000:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-09-23T13:42:48.445000:   File "/opt/venv/lib/python3.11/site-packages/cads_api_client/legacy_api_client.py", line 134, in wrapper
2024-09-23T13:42:48.445000:     return func(*args, **kwargs)
2024-09-23T13:42:48.445000:            ^^^^^^^^^^^^^^^^^^^^^
2024-09-23T13:42:48.445000:   File "/opt/venv/lib/python3.11/site-packages/cads_api_client/api_client.py", line 77, in submit_and_wait_on_result
2024-09-23T13:42:48.445000:     return self.retrieve_api.submit_and_wait_on_result(
2024-09-23T13:42:48.445000:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-09-23T13:42:48.445000:   File "/opt/venv/lib/python3.11/site-packages/cads_api_client/processing.py", line 451, in submit_and_wait_on_result
2024-09-23T13:42:48.445000:     return remote.make_results()
2024-09-23T13:42:48.445000:            ^^^^^^^^^^^^^^^^^^^^^
2024-09-23T13:42:48.445000:   File "/opt/venv/lib/python3.11/site-packages/cads_api_client/processing.py", line 260, in make_results
2024-09-23T13:42:48.445000:     raise ValueError(f"Result not ready, job is {status}")
2024-09-23T13:42:48.445000: ValueError: Result not ready, job is running
```
