### PR TITLE
Add Climate Resource copyright attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -177,6 +177,7 @@
    END OF TERMS AND CONDITIONS
 
    Copyright 2016-2022 The University of Melbourne
+   Copyright 2024 Climate Resource
    Copyright 2023-present The Superpower Institute
 
    Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Description

Adds Climate Resource copyright attribution for 2024 to the text of the license.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`)

## Notes
