### PR TITLE
Replace ads-beta URLs with prod ads URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,4 @@ EARTHDATA_USERNAME=
 EARTHDATA_PASSWORD=
 # Login information for the CDS api
 CDSAPI_KEY=
-CDSAPI_URL=https://ads-beta.atmosphere.copernicus.eu/api
+CDSAPI_URL=https://ads.atmosphere.copernicus.eu/api

--- a/changelog/86.chore.md
+++ b/changelog/86.chore.md
@@ -1,0 +1,1 @@
+Update ADS API URLs from ads-beta to new production domain ads.atmosphere.copernicus.eu

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -52,4 +52,4 @@ These will be used by the `fetch_tropomi.py` script to authenticate with the GES
 ## CAMS Login
 Used to fetch CAMS data during the cmaq_preprocess step.
  
-This requires a CAMS account, which can be created at the ECMWF [Atmosphere Data Store](https://ads-beta.atmosphere.copernicus.eu/).
+This requires a CAMS account, which can be created at the ECMWF [Atmosphere Data Store](https://ads.atmosphere.copernicus.eu/).


### PR DESCRIPTION
## Description

The legacy ADS system has been decommissioned, and ads URLs now point to their new production system, previously known as ads-beta. The ads-beta URLs will be redirected to the production infrastructure for the next month, but we can now access the production ADS system through the previous URL.

https://forum.ecmwf.int/t/goodbye-legacy-ads-hello-new-atmosphere-data-store-ads/6381

> url: https://ads-beta.atmosphere.copernicus.eu/api → url: https://ads.atmosphere.copernicus.eu/api

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests passing
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`)

## Notes
