### PR TITLE
archiving first forward run and exiting, should be replaced by archiving every forward run if we could index them

### DIFF
--- a/src/fourdvar/_main_driver.py
+++ b/src/fourdvar/_main_driver.py
@@ -55,6 +55,8 @@ def cost_func(vector):
         data_access.prev_vector = vector.copy()
 
     simulated = transform(model_out, d.ObservationData)
+    simulated.archive(f"forward-test.ncf", force_lite=True)
+    raise SystemExit('exiting after forward run')
 
     residual = d.ObservationData.get_residual(observed, simulated)
     w_residual = d.ObservationData.error_weight(residual)
@@ -121,7 +123,8 @@ def gradient_func(vector):
         data_access.prev_vector = vector.copy()
 
     simulated = transform(model_out, d.ObservationData)
-
+    simulated.archive(f"forward-test.ncf", force_lite=True)
+    raise SystemExit('exiting after forward run')
     residual = d.ObservationData.get_residual(observed, simulated)
     w_residual = d.ObservationData.error_weight(residual)
 


### PR DESCRIPTION
-------

## Description
this PR should *not* be merged. Its function is to create a container
with a special diagnostic to test the monthly runs. I don't think I
can change its status to draft from the cli, but it should produce a
container we can run.
## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`)

## Notes
this should be closed once we've used the diagnostic