### PR TITLE
feat: Add retry policy with exponential backoff to tropomi

### DIFF
--- a/changelog/89.breaking.md
+++ b/changelog/89.breaking.md
@@ -1,0 +1,3 @@
+`fetch_tropomi_data` now fails if any network requests fail.
+This is more robust than the previous behavior, which would silently ignore any failed requests leading
+to an incomplete or missing observational dataset.

--- a/changelog/89.feature.md
+++ b/changelog/89.feature.md
@@ -1,0 +1,2 @@
+Add retry behaviour when fetching tropomi data
+Add `CHK_PATH` environment variable for defining the location of checkpoint files in CMAQ.

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -2,34 +2,35 @@
 
 The following environment variables are configurable:
 
-| Variable            | Type  | Description                                                         | Default                                    |
-|---------------------|-------|---------------------------------------------------------------------|--------------------------------------------|
-| DOMAIN_NAME         | str   | Defines the target domain                                           | aust10km                                   |
-| DOMAIN_VERSION      | str   | Version of the target domain                                        | v1                                         |
-| DOMAIN_MCIP_SUFFIX  | str   | Suffix for the generated MCIP files                                 | ${DOMAIN_NAME}_${DOMAIN_VERSION}           |
-| START_DATE          | date  | Start date of the run                                               | 2022-07-01                                 |
-| END_DATE            | date  | End date of the run (inclusive)                                     | 2022-07-30                                 |
-| STORE_PATH          | str   | Full path to the branch-specific data.                              | N/A                                        |          
-| EXPERIMENT          | str   | Name of the experiment being run                                    | 202207_test                                |
-| TEMPLATE_DIR        | str   | Path to the CMAQ template directory                                 | {SOURCE_PATH}/templates                    |
-| CMAQ_SOURCE_DIR     | str   | Path to the root of the CMAQ source directory                       | N/A                                        |
-| MCIP_SOURCE_DIR     | str   | Path to the root MCIP source directory                              | N/A                                        |
-| MET_DIR             | path  | Output directory for the MCIP data                                  | N/A                                        |
-| CTM_DIR             | path  | Output directory for the CMAQ template files                        | N/A                                        |
-| WRF_DIR             | path  | Output directory for the WRF outputs (from setup-wrf)               | N/A                                        |
-| GEO_DIR             | path  | Directory containing the `geo_em.d??.nc` file (from setup-wrf)      | N/A                                        |
-| OBS_FILE_GLOB       | str   | Glob string to match the observation files relative to {STORE_PATH} | "input/test_obs.pic.gz"                    |
-| PRIOR_FILE          | path  | Path to the concentration prior file                                | N/A                                        |
-| CAMS_FILE           | path  | Path to the CAMS CH4 emissions file                                 | N/A                                        |
-| ICON_FILE           | path  | Path to ICON template file                                          | N/A                                        |
-| BCON_FILE           | path  | Path to BCON template file                                          | N/A                                        |
-| EMIS_FILE           | path  | Path to emissions files                                             | {CMAQ_BASE}/emissions/emis.<YYYY-MM-DD>.nc |
-| FORCE_FILE          | path  | Path to the template forcing file                                   | {CMAQ_BASE}/force/ADJ_FORCE.<YYYYMMDD>.nc  |
-| ADJOINT_FWD         | path  | Path to forward adjoint executable                                  | N/A                                        |
-| ADJOINT_BWD         | path  | Path to backward adjoint executable                                 | N/A                                        |
-| NUM_PROC_COLS       | int   | Number of processors to use for the columns                         | 1                                          |
-| NUM_PROC_ROW        | int   | Number of processors to use for the rows                            | 1                                          |
-| MAX_ITERATIONS      | int   | Maximum successful iterations performed by fourdvar                 | 20                                         |
+| Variable           | Type  | Description                                                         | Default                                    |
+|--------------------|-------|---------------------------------------------------------------------|--------------------------------------------|
+| DOMAIN_NAME        | str   | Defines the target domain                                           | aust10km                                   |
+| DOMAIN_VERSION     | str   | Version of the target domain                                        | v1                                         |
+| DOMAIN_MCIP_SUFFIX | str   | Suffix for the generated MCIP files                                 | ${DOMAIN_NAME}_${DOMAIN_VERSION}           |
+| START_DATE         | date  | Start date of the run                                               | 2022-07-01                                 |
+| END_DATE           | date  | End date of the run (inclusive)                                     | 2022-07-30                                 |
+| STORE_PATH         | str   | Full path to the branch-specific data.                              | N/A                                        |          
+| EXPERIMENT         | str   | Name of the experiment being run                                    | 202207_test                                |
+| TEMPLATE_DIR       | str   | Path to the CMAQ template directory                                 | {STORE_PATH}/templates                    |
+| CMAQ_SOURCE_DIR    | str   | Path to the root of the CMAQ source directory                       | N/A                                        |
+| MCIP_SOURCE_DIR    | str   | Path to the root MCIP source directory                              | N/A                                        |
+| MET_DIR            | path  | Output directory for the MCIP data                                  | N/A                                        |
+| CTM_DIR            | path  | Output directory for the CMAQ template files                        | N/A                                        |
+| WRF_DIR            | path  | Output directory for the WRF outputs (from setup-wrf)               | N/A                                        |
+| GEO_DIR            | path  | Directory containing the `geo_em.d??.nc` file (from setup-wrf)      | N/A                                        |
+| CHK_PATH            | path  | Directory to store CMAQ checkpoint files                            | {CMAQ_BASE}/chkpnt                         |
+| OBS_FILE_GLOB      | str   | Glob string to match the observation files relative to {STORE_PATH} | "input/test_obs.pic.gz"                    |
+| PRIOR_FILE         | path  | Path to the concentration prior file                                | N/A                                        |
+| CAMS_FILE          | path  | Path to the CAMS CH4 emissions file                                 | N/A                                        |
+| ICON_FILE          | path  | Path to ICON template file                                          | N/A                                        |
+| BCON_FILE          | path  | Path to BCON template file                                          | N/A                                        |
+| EMIS_FILE          | path  | Path to emissions files                                             | {CMAQ_BASE}/emissions/emis.<YYYY-MM-DD>.nc |
+| FORCE_FILE         | path  | Path to the template forcing file                                   | {CMAQ_BASE}/force/ADJ_FORCE.<YYYYMMDD>.nc  |
+| ADJOINT_FWD        | path  | Path to forward adjoint executable                                  | N/A                                        |
+| ADJOINT_BWD        | path  | Path to backward adjoint executable                                 | N/A                                        |
+| NUM_PROC_COLS      | int   | Number of processors to use for the columns                         | 1                                          |
+| NUM_PROC_ROW       | int   | Number of processors to use for the rows                            | 1                                          |
+| MAX_ITERATIONS     | int   | Maximum successful iterations performed by fourdvar                 | 20                                         |
 
 
 For values with a default of N/A an exception will be raised if

--- a/scripts/obs_preprocess/fetch_tropomi.py
+++ b/scripts/obs_preprocess/fetch_tropomi.py
@@ -145,7 +145,7 @@ def fetch_data(config_file, start, end, output):
     }
 
     while response["result"]["Status"] in ["Accepted", "Running"]:
-        sleep(5)
+        sleep(1)
         response = get_http_data(status_request, session)
         status = response["result"]["Status"]
         percent = response["result"]["PercentCompleted"]

--- a/scripts/obs_preprocess/fetch_tropomi.py
+++ b/scripts/obs_preprocess/fetch_tropomi.py
@@ -15,6 +15,7 @@ from typing import Any
 import click
 import dotenv
 import requests
+from requests.adapters import Retry, HTTPAdapter
 
 # Load environment variables from a local .env file
 dotenv.load_dotenv()
@@ -37,6 +38,18 @@ def create_session() -> requests.Session:
     """
     session = requests.Session()
 
+    # Retry on 429 (too many requests) and 500 status codes
+    # Exponential backoff with jitter to avoid a thundering herd
+    # Maximum duration would be 5 * 2 ** 6 = 320 seconds
+    retries = Retry(
+        total=6,
+        backoff_factor=5.0,
+        backoff_jitter=1.0,
+        status_forcelist=[429, 500, 502, 503, 504]
+    )
+    session.mount('http://', HTTPAdapter(max_retries=retries))
+    session.mount('https://', HTTPAdapter(max_retries=retries))
+
     credentials_path = Path("~/.netrc").expanduser()
     if not credentials_path.exists():
         # Create the .netrc file with the Earthdata credentials
@@ -44,7 +57,6 @@ def create_session() -> requests.Session:
             raise click.ClickException(
                 "EARTHDATA_USERNAME or EARTHDATA_PASSWORD environment variables missing"
             )
-            raise click.Abort()
 
         print("Writing .netrc file")
 
@@ -67,6 +79,7 @@ def get_http_data(body: dict[str, Any], session: requests.Session):
     # Check for errors
     if content["type"] == "jsonwsp/fault":
         print("API Error: faulty request")
+        raise RuntimeError(f"Invalid type found in {content}")
     return content
 
 
@@ -227,7 +240,9 @@ def fetch_data(config_file, start, end, output):
                 print("Unauthorised: Check your Earthdata credentials in the ~/.netrc file")
             print("Help for downloading data is at https://disc.gsfc.nasa.gov/data-access")
 
-            # TODO: decide what to do if a single file fails to download
+            # Abort if any files fail to download
+            raise click.Abort()
+
     print("Data fetched successfully!")
 
 

--- a/src/fourdvar/params/cmaq_config.py
+++ b/src/fourdvar/params/cmaq_config.py
@@ -112,7 +112,7 @@ if use_jobfs is True:
         logger.warning("cannot find PBS_JOBFS, use_jobfs can only be run with qsub.")
         chk_path = os.path.join(cmaq_base, "chkpnt")
 else:
-    chk_path = os.path.join(cmaq_base, "chkpnt")
+    chk_path = env.str("CHK_PATH", os.path.join(cmaq_base, "chkpnt"))
 
 mcip_met_path = os.path.join(mcip_output_path, "<YYYY-MM-DD>", "d01")
 mcip_grid_path = os.path.join(mcip_output_path, "<YYYY-MM-DD>", "d01")

--- a/tests/integration/obs_preprocess/test_fetch_tropomi.py
+++ b/tests/integration/obs_preprocess/test_fetch_tropomi.py
@@ -57,3 +57,23 @@ def test_fetch_missing_creds(monkeypatch, env_var):
         match="EARTHDATA_USERNAME or EARTHDATA_PASSWORD environment variables missing",
     ):
         fetch_tropomi.create_session()
+
+
+def test_fetch_invalid_date(tmpdir, root_dir):
+    runner = CliRunner()
+    result = runner.invoke(
+        fetch_tropomi.fetch_data,
+        [
+            "-c",
+            str(root_dir / "config" / "obs_preprocess" / "config.austtest.json"),
+            "-s",
+            "1900-07-01",
+            "-e",
+            "1901-07-02",
+            str(tmpdir),
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert str(result.exception) == '500 Server Error: Internal Server Error for url: https://disc.gsfc.nasa.gov/service/subset/jsonwsp'
+

--- a/tests/integration/obs_preprocess/test_fetch_tropomi.py
+++ b/tests/integration/obs_preprocess/test_fetch_tropomi.py
@@ -6,7 +6,7 @@ import pytest
 from click.testing import CliRunner
 from scripts.obs_preprocess import fetch_tropomi
 
-
+# This hits the api
 def test_fetch(tmpdir, root_dir):
     runner = CliRunner()
     result = runner.invoke(
@@ -59,6 +59,7 @@ def test_fetch_missing_creds(monkeypatch, env_var):
         fetch_tropomi.create_session()
 
 
+# This hits the api with invalid data
 def test_fetch_invalid_date(tmpdir, root_dir):
     runner = CliRunner()
     result = runner.invoke(


### PR DESCRIPTION
## Description

* Adds retries with exponential backoff for tropomi results
* Failing files now cause the script to abort
* Added CHK_PATH environment variable for defining the location of check point files

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`)

## Notes
