### PR TITLE
feat: Skip running setup_for_CMAQ

### DIFF
--- a/.env.docker-monthly
+++ b/.env.docker-monthly
@@ -9,7 +9,7 @@
 FORCE_UPDATE=false
 OBS_FILE_GLOB="${STORE_PATH}/${DOMAIN_NAME}/daily/*/*/*/input/test_obs.pic.gz"
 MET_DIR="${STORE_PATH}/${DOMAIN_NAME}/daily/<YYYY>/<MM>/<DD>/mcip"
-CTM_DIR="${STORE_PATH}/cmaq"
+CTM_DIR="${STORE_PATH}/${DOMAIN_NAME}/daily/<YYYY>/<MM>/<DD>/cmaq"
 CAMS_FILE="${STORE_PATH}/cams/cams_eac4_methane_${START_DATE}-${END_DATE}.nc"
 
 # Not used, but required

--- a/changelog/93.improvement.md
+++ b/changelog/93.improvement.md
@@ -1,0 +1,1 @@
+Add option to not recalculate the initial/boundary conditions during the CMAQ preprocessing step.

--- a/scripts/cmaq_preprocess/run-cmaq-preprocess.sh
+++ b/scripts/cmaq_preprocess/run-cmaq-preprocess.sh
@@ -11,6 +11,7 @@ set -x
 source scripts/environment.sh
 
 SKIP_CAMS_DOWNLOAD=${SKIP_CAMS_DOWNLOAD:-}
+SKIP_CMAQ_SETUP=${SKIP_CMAQ_SETUP:-}
 SKIP_TEMPLATE_GENERATION=${SKIP_TEMPLATE_GENERATION:-}
 
 # Skip the CAMS download if the variable is set to anything other than an empty string
@@ -23,8 +24,12 @@ else
   echo "Skipping CAMS download"
 fi
 
-echo "Preparing CMAQ input files"
-python scripts/cmaq_preprocess/setup_for_cmaq.py
+if [[ -z "${SKIP_CMAQ_SETUP}" ]]; then
+  echo "Preparing CMAQ input files"
+  python scripts/cmaq_preprocess/setup_for_cmaq.py
+else
+  echo "Skipping CMAQ setup"
+fi
 
 # Skip the template generation if SKIP_TEMPLATE_GENERATION is set to anything other than an empty string
 if [[ -n "${SKIP_TEMPLATE_GENERATION}" ]]; then

--- a/scripts/load_from_archive.py
+++ b/scripts/load_from_archive.py
@@ -31,7 +31,7 @@ def main():
     for date in date_range(START_DATE, END_DATE):  # this is inclusive of END_DATE
         for path in [
             ["input"],
-            ["mcip"],
+            ["cmaq"],
         ]:
             _sync_daily_directory(date, path)
 


### PR DESCRIPTION
## Description

Add option to not run the setup_for_cmaq step during the CMAQ preprocessing step. This is useful for monthly runs where the cmaq data has already been calculated. 

I don't think we need the MCIP output anymore in that case which is great as that can be 100s of GB to download.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`)

## Notes
