### PR TITLE
fix: Ensure the checkpoint directory exists on each run

### DIFF
--- a/changelog/94.fix.md
+++ b/changelog/94.fix.md
@@ -1,0 +1,1 @@
+The checkpoint directory is automatically created which running the model

--- a/src/fourdvar/util/cmaq_handle.py
+++ b/src/fourdvar/util/cmaq_handle.py
@@ -100,6 +100,9 @@ def setup_run():
     else:
         env_dict["AVG_CONC_SPCS"] = str(cmaq_config.avg_conc_spcs)
 
+    # Ensure the directory for the checkpoint files already exists
+    fh.ensure_path(cmaq_config.chk_path)
+
     env_dict["ADJ_CHEM_CHK"] = cmaq_config.chem_chk + " -v"
     env_dict["ADJ_VDIFF_CHK"] = cmaq_config.vdiff_chk + " -v"
     env_dict["ADJ_AERO_CHK"] = cmaq_config.aero_chk + " -v"


### PR DESCRIPTION
## Description

Ensure the checkpoint directory exists on each run

We may write checkpoints to directories that don't already exist.


## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`)

## Notes
