### PR TITLE
adding prior emissions to output fluxes

### DIFF
--- a/changelog/95.improvement.md
+++ b/changelog/95.improvement.md
@@ -1,0 +1,1 @@
+adding prior emissions to archived file containing posterior emissions

--- a/src/postproc/calculate_average_emissions.py
+++ b/src/postproc/calculate_average_emissions.py
@@ -40,10 +40,14 @@ def calculate_average_emissions(
         copy_attributes( in_ds, out_ds, delete_attrs = ['NVARS', 'NLAYS'])
         cell_area = in_ds.XCELL * in_ds.YCELL
         conv_fac = SPECIES_MOLEMASS[ species] * G2KG
+        prior_emis_mean_output = prior_emis_mean_surf * conv_fac /cell_area
         posterior_emis_mean_output = posterior_emis_mean_surf * conv_fac /cell_area
         # now create coordinates, missing from input
         x = in_ds.XORIG + 0.5*in_ds.XCELL + np.arange(in_ds.NCOLS) * in_ds.XCELL
         y = in_ds.YORIG + 0.5*in_ds.YCELL + np.arange( in_ds.NROWS) * in_ds.YCELL
+        prior_emis_mean_xr = xr.DataArray( prior_emis_mean_output, coords={'y':y, 'x':x})
+        prior_emis_mean_xr.attrs['units'] = 'kg/m**2/s'
+        out_ds['prior_'+species] = prior_emis_mean_xr
         posterior_emis_mean_xr = xr.DataArray( posterior_emis_mean_output, coords={'y':y, 'x':x})
         posterior_emis_mean_xr.attrs['units'] = 'kg/m**2/s'
         out_ds[species] = posterior_emis_mean_xr

--- a/src/postproc/calculate_average_emissions.py
+++ b/src/postproc/calculate_average_emissions.py
@@ -27,9 +27,9 @@ def calculate_average_emissions(
     prior_emis_list = []
     for filename in prior_emis_files:
         with xr.open_dataset( filename) as xrds:
-            prior_emis_list.append( xrds[species].to_numpy())
+            prior_emis_list.append( xrds[species].to_numpy().mean(axis=0)) # average ove rhours
     prior_emis_array = np.array( prior_emis_list)
-    prior_emis_mean_3d = prior_emis_array.mean(axis=(0,1))
+    prior_emis_mean_3d = prior_emis_array.mean(axis=(0)) # average over days
     prior_emis_mean_surf = prior_emis_mean_3d[0,...]
     posterior_multiplier = get_posterior( archive_dir, species,
                                           iter_template, designated_posterior_file)


### PR DESCRIPTION
## Description
We need prior emissions in the same form as the posterior for display.
this is most consistently achieved in the calculate_average_emissions
post-processing step
## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`)

## Notes