### PR TITLE
fix: Handle case where log streams don't exist

### DIFF
--- a/changelog/97.fix.md
+++ b/changelog/97.fix.md
@@ -1,0 +1,1 @@
+Handle archiving log streams that are no longer available


### PR DESCRIPTION
## Description

Fixes edgecase where log streams are not available anymore.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`)

## Notes
This might be a side-effect of having to redrive our daily runs so the log stream was cleaned up after x days. Local testing suggested that only one stream was unavailable