### PR TITLE
Update all ADS URLs to remove references to ads-beta

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -110,7 +110,7 @@ jobs:
         if: steps.cache-cams.outputs.cache-hit != 'true'
         env:
           CDSAPI_KEY: ${{ secrets.CDSAPI_ADS_KEY }}
-          CDSAPI_URL: https://ads-beta.atmosphere.copernicus.eu/api
+          CDSAPI_URL: https://ads.atmosphere.copernicus.eu/api
         run: |
           cd /opt/project
           # This can take a few minutes as the CAMS data is stored on tape
@@ -121,7 +121,7 @@ jobs:
       - name: Run pytest
         env:
           CDSAPI_KEY: ${{ secrets.CDSAPI_ADS_KEY }}
-          CDSAPI_URL: https://ads-beta.atmosphere.copernicus.eu/api
+          CDSAPI_URL: https://ads.atmosphere.copernicus.eu/api
           EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
           EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
           TARGET: docker-test
@@ -147,7 +147,7 @@ jobs:
       - name: Run e2e test
         env:
           CDSAPI_KEY: ${{ secrets.CDSAPI_ADS_KEY }}
-          CDSAPI_URL: https://ads-beta.atmosphere.copernicus.eu/api
+          CDSAPI_URL: https://ads.atmosphere.copernicus.eu/api
           EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
           EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
           # Uses the local checked-in WRF and prior data

--- a/changelog/102.chore.md
+++ b/changelog/102.chore.md
@@ -1,0 +1,1 @@
+Update ADS API URLs from ads-beta to new production domain ads.atmosphere.copernicus.eu in CI/CD.


### PR DESCRIPTION
## Description

For some reason, the previous PR #86 didn't actually update any of the ADS URLs in the CI configuration.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`)

## Notes
