### PR TITLE
Fix docker tags for releases in build_docker workflow

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -50,10 +50,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: "${{ env.REGISTRY }}/${{ env.IMAGE }}"
+          # tag as `build-XYZ` since images need to be tagged to push
           tags: |
             type=schedule
             type=ref,event=branch
             type=ref,event=pr
+            type=raw,value=build-${{ github.run_number }}
       - name: Build and push image
         uses: docker/build-push-action@v5
         id: build

--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -238,6 +238,11 @@ jobs:
             docker tag "${{ needs.build.outputs.registry-image-id }}" "$tag"
             docker push "$tag"
           done
+      - name: Remove build tag from published image
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          delete-tags: build-${{ github.run_number }}
 
   # Push the image to ECR as well
   push-ecr:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,13 +41,8 @@ jobs:
         uses: actions/setup-python@v4
       - name: Install poetry
         uses: abatilo/actions-poetry@v2
-      - name: Add version to environment
-        run: |
-          poetry install --only main
-
       - name: Install towncrier
-        run: |
-          poetry run pip install towncrier
+        run: poetry run pip install towncrier
 
       - name: Determine release version
         id: release-version

--- a/changelog/104.bug.md
+++ b/changelog/104.bug.md
@@ -1,1 +1,0 @@
-Fix docker build to only push stable image tags when container tests pass

--- a/changelog/109.fix.md
+++ b/changelog/109.fix.md
@@ -1,0 +1,1 @@
+Fix release images failing docker push because they have no valid tags

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,15 +21,18 @@ of rst and use slightly different categories.
 
 ## openmethane v0.5.2 (2024-11-21)
 
+### 🐛 Bug Fixes
+
+- Fix docker build to only push stable image tags when container tests pass.
+
 ### 🎉 Improvements
 
-- Combine bump and release workflows into a simplified release process
-
-  Update container tagging strategy for latest and stable tags ([#103](https://github.com/openmethane/openmethane/pulls/103))
+- Combine bump and release workflows into a simplified release process.
+- Update container tagging strategy for latest and stable tags ([#103](https://github.com/openmethane/openmethane/pulls/103)).
 
 ### 🔧 Trivial/Internal Changes
 
-- [#106](https://github.com/openmethane/openmethane/pulls/106)
+- Small changes to GHA workflows to bring them inline with improvements made in other repos.
 
 
 ## openmethane v0.5.1 (2024-11-19)
@@ -50,7 +53,7 @@ of rst and use slightly different categories.
 ### 🆕 Features
 
 - Add retry behaviour when fetching tropomi data
-  Add `CHK_PATH` environment variable for defining the location of checkpoint files in CMAQ. ([#89](https://github.com/openmethane/openmethane/pulls/89))
+- Add `CHK_PATH` environment variable for defining the location of checkpoint files in CMAQ. ([#89](https://github.com/openmethane/openmethane/pulls/89))
 
 ### 🎉 Improvements
 
@@ -109,10 +112,8 @@ of rst and use slightly different categories.
 - Removed a duplicate global entry for the start/end date of a simulation
   and unified how parameters are named throughout `fourdvar`. ([#54](https://github.com/openmethane/openmethane/pulls/54))
 - Load previous MCIP data when loading from the archive.
-
-  Added support for using fourdvar date identifiers in the CMAQ preprocessing directories.
-
-  Removed an ununsed `diurnal` parameter from `fourdvar`. ([#57](https://github.com/openmethane/openmethane/pulls/57))
+- Added support for using fourdvar date identifiers in the CMAQ preprocessing directories.
+- Removed an ununsed `diurnal` parameter from `fourdvar`. ([#57](https://github.com/openmethane/openmethane/pulls/57))
 - Log chi squared and bias values during the cost function execution ([#59](https://github.com/openmethane/openmethane/pulls/59))
 - Don't clean up data for failed runs to make runs easily restartable ([#60](https://github.com/openmethane/openmethane/pulls/60))
 - Added bias correction step for CAMS data.


### PR DESCRIPTION
## Description

The build_docker workflow is failing for releases because they no longer have any image tags. This introduces a `build-XYZ` tag for the initial build, which is then removed after tests pass when the image's "proper" tags are pushed.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
