### PR TITLE
remove any role for atmosphere above top of model

### DIFF
--- a/changelog/112.improvement.md
+++ b/changelog/112.improvement.md
@@ -1,6 +1,2 @@
 Set top of model domain to top pressure level. Removes impact of
-unmodelled top of atmosphere on observation operator. Responds to
-Issue #111
-Set top of model domain to top pressure level. Removes impact of
-unmodelled top of atmosphere on observation operator. Responds to
-Issue #111
+unmodelled top of atmosphere on observation operator. Resolves #111.

--- a/changelog/112.improvement.md
+++ b/changelog/112.improvement.md
@@ -1,0 +1,6 @@
+Set top of model domain to top pressure level. Removes impact of
+unmodelled top of atmosphere on observation operator. Responds to
+Issue #111
+Set top of model domain to top pressure level. Removes impact of
+unmodelled top of atmosphere on observation operator. Responds to
+Issue #111

--- a/src/obs_preprocess/model_space.py
+++ b/src/obs_preprocess/model_space.py
@@ -219,11 +219,9 @@ class ModelSpace:
 
     def get_pressure_weight(self, target_coord):
         pbound = self.get_pressure_bounds(target_coord)
-        # assign everything above the top layer to the top layer
-        pbound[-1] = 0.0
         # calculate pressure weight per layer
         pdiff = pbound[:-1] - pbound[1:]
-        pweight = pdiff / pbound[0]
+        pweight = pdiff / (pbound[0] -pbound[-1])
         return pweight
 
     def pressure_interp(self, obs_pressure, obs_value, target_coord):


### PR DESCRIPTION
Responds to #111
Set top pressure to that of top boundary rather than zero.
At the moment this means that get_pressure_weight reverses
get_pressure_bounds and just returns the sigma thicknesses. We keep it
this way since we may need the pressures for some other
characteristics of the weighting function

-------

## Description

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`

## Notes