### PR TITLE
Fix actions script that extracts version from git ref

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -163,7 +163,7 @@ jobs:
         if: startsWith(github.event.ref, 'refs/tags/v')
         run: |
           TAG_REF="${{ github.event.ref }}"
-          TAG_VERSION=${TAG_REF/"refs\/tags\/"}
+          TAG_VERSION=${TAG_REF#"refs/tags/"}
           if [ "$OPENMETHANE_VERSION" != "$TAG_VERSION" ]; then
             echo "OPENMETHANE_VERSION is $OPENMETHANE_VERSION; expected version is $TAG_VERSION"
             exit 1

--- a/changelog/118.fix.md
+++ b/changelog/118.fix.md
@@ -1,0 +1,1 @@
+Fix GitHub Actions script to support dash shell syntax


### PR DESCRIPTION

## Description

The previous implementation used substitution which is supported by bash, but not by dash. The replacement is simpler and should work in the ubuntu-latest image where dash appears to be the default shell.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
