### PR TITLE
Fix version being incorrectly parsed in actions

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -45,6 +45,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract version from pyproject.toml
+        id: version
+        run: |
+          PACKAGE_VERSION=$(grep -oP '^version = "\K(.+)(?=")' pyproject.toml)
+          echo "Package version is: $PACKAGE_VERSION"
+          echo "version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -70,7 +76,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
-            OPENMETHANE_VERSION=${{ steps.meta.outputs.version }}
+            OPENMETHANE_VERSION=${{ steps.version.outputs.version }}
           push: true
           pull: false
           cache-from: type=gha

--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -49,7 +49,6 @@ jobs:
         id: version
         run: |
           PACKAGE_VERSION=$(grep -oP '^version = "\K(.+)(?=")' pyproject.toml)
-          echo "Package version is: $PACKAGE_VERSION"
           echo "version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/changelog/119.fix.md
+++ b/changelog/119.fix.md
@@ -1,0 +1,1 @@
+Fix OPENMETHANE_VERSION being incorrectly populated in container images


### PR DESCRIPTION
## Description

Although this was previously working, it appears that the `OPENMETHANE_VERSION` environment variable being built into the container is now being populated with `build-XYZ` instead of `vA.B.C`.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
