### PR TITLE
Disable wipeout of bwd run in cmaq_preprocess

### DIFF
--- a/changelog/122.fix.md
+++ b/changelog/122.fix.md
@@ -1,0 +1,1 @@
+Revert bwd wipeout change in cmaq_preprocess

--- a/scripts/cmaq_preprocess/make_template.py
+++ b/scripts/cmaq_preprocess/make_template.py
@@ -85,7 +85,8 @@ if str(cmaq_config.sense_emis_lays).lower() == "template":
 
 # clear fwd and bwd logs from previous runs to prevent a log write error
 cmaq_handle.wipeout_fwd()
-cmaq_handle.wipeout_bwd()
+# disable clearing of bwd working folder as this may be the cause of #121
+#cmaq_handle.wipeout_bwd()
 
 # generate sample files by running 1 day of cmaq (fwd & bwd)
 cmaq_handle.run_fwd_single(date_defn.start_date, is_first=True)


### PR DESCRIPTION

## Description

Possible resolution for #121 .

We believe that this change in `cmaq_preprocess/make_template.py` is the only substantial change to the codebase that has occurred since the last successful monthly run, so we're temporarily reverting this change to see if we can complete a monthly reprocessing run with the bias fixes.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
