### PR TITLE
 Add "daily" mode to `load_from_archive.py`

### DIFF
--- a/scripts/load_from_archive.py
+++ b/scripts/load_from_archive.py
@@ -27,17 +27,25 @@ START_DATE = env.date("START_DATE")
 END_DATE = env.date("END_DATE")
 
 
-def main():
+def monthly():
     for date in date_range(START_DATE, END_DATE):  # this is inclusive of END_DATE
+        daily_destination_path = pathlib.Path(
+            DOMAIN_NAME,
+            "daily",
+            str(date.year),
+            f"{date.month:02}",
+            f"{date.day:02}",
+        )
+
         for path in [
             ["input"],
             ["cmaq"],
             ["mcip"],
         ]:
-            _sync_daily_directory(date, path)
+            _sync_daily_directory(date, path, daily_destination_path)
 
 
-def _sync_daily_directory(date: datetime.date, path: list[str]):
+def _sync_daily_directory(date: datetime.date, path: list[str], destination: pathlib.Path):
     """
     Sync output from an archive of a successful daily workflow.
 
@@ -51,21 +59,21 @@ def _sync_daily_directory(date: datetime.date, path: list[str]):
         This doesn't currently fetch individual files,
         instead an entire directory including its subdirectories are fetched.
     """
-    daily_prefix = (
+    daily_archive_path = (
         DOMAIN_NAME,
         "daily",
         str(date.year),
         f"{date.month:02}",
         f"{date.day:02}",
     )
-    s3_path = "/".join((TARGET_BUCKET, *daily_prefix, *path)).rstrip("/")
+    s3_path = "/".join((TARGET_BUCKET, *daily_archive_path, *path)).rstrip("/")
     s3_path = s3_path + "/"  # S3 directory paths must end with a slash
 
     # Verify that the path exists
     # Raises CalledProcessError if the path doesn't exist
     subprocess.run(["aws", "s3", "ls", s3_path], check=True, capture_output=False)
 
-    local_path = STORE_PATH.joinpath(*daily_prefix, *path)
+    local_path = STORE_PATH.joinpath(destination, *path)
     local_path.mkdir(parents=True, exist_ok=True)
     logging.info(f"Downloading {s3_path} to {local_path}")
 
@@ -83,4 +91,4 @@ def date_range(start_date: datetime.date, end_date: datetime.date):
 
 if __name__ == "__main__":
     logging.basicConfig(level=env.str("LOG_LEVEL", "DEBUG"))
-    main()
+    monthly()

--- a/scripts/load_from_archive.py
+++ b/scripts/load_from_archive.py
@@ -1,5 +1,6 @@
 """
-Load previous month's output from the archive for a monthly run.
+Load previous daily output from the archive for a monthly run or a daily
+re-processing.
 
 This is intended to be run as part of the production deployment
 so references environment variables that may not be available.
@@ -11,7 +12,7 @@ The archived data is stored in the prefix ${DOMAIN_NAME}/daily/${YEAR}/${MONTH}/
 The script downloads specific directories from that archive,
 into ${STORE_PATH}/${DOMAIN_NAME}/daily/${YEAR}/${MONTH}/${DAY}.
 """
-
+import click
 import datetime
 import logging
 import pathlib
@@ -27,7 +28,29 @@ START_DATE = env.date("START_DATE")
 END_DATE = env.date("END_DATE")
 
 
+@click.command()
+@click.option(
+    "--sync", "-s",
+    help="Sync a single day ('daily') or a range of dates for a monthly run ('monthly')",
+    default="monthly",
+    show_default=True,
+    type=click.Choice(['monthly', 'daily'])
+)
+def load_from_archive(sync: str = "monthly"):
+    match sync:
+        case "daily":
+            daily()
+
+        # default case catches "monthly" as well
+        case _:
+            monthly()
+
 def monthly():
+    """
+    Sync a subset of the daily output for a range of dates into the working
+    folder for the current execution. This daily data is needed for the monthly
+    workflow.
+    """
     for date in date_range(START_DATE, END_DATE):  # this is inclusive of END_DATE
         daily_destination_path = pathlib.Path(
             DOMAIN_NAME,
@@ -45,7 +68,20 @@ def monthly():
             _sync_daily_directory(date, path, daily_destination_path)
 
 
-def _sync_daily_directory(date: datetime.date, path: list[str], destination: pathlib.Path):
+def daily():
+    """
+    Sync a subset of the daily output for a single date into the working
+    folder for the current execution. This will allow a subsequent daily run
+    on the same day to skip expensive re-processing for data that isn't
+    likely to change.
+    """
+    for path in [
+        ["mcip"],
+    ]:
+        _sync_daily_directory(START_DATE, path, pathlib.Path('.'), allow_missing=True)
+
+
+def _sync_daily_directory(date: datetime.date, path: list[str], destination: pathlib.Path, allow_missing: bool = False):
     """
     Sync output from an archive of a successful daily workflow.
 
@@ -71,7 +107,14 @@ def _sync_daily_directory(date: datetime.date, path: list[str], destination: pat
 
     # Verify that the path exists
     # Raises CalledProcessError if the path doesn't exist
-    subprocess.run(["aws", "s3", "ls", s3_path], check=True, capture_output=False)
+    try:
+        subprocess.run(["aws", "s3", "ls", s3_path], check=True, capture_output=False)
+    except subprocess.CalledProcessError as error:
+        # if no data is available, there is no archive to restore
+        if allow_missing:
+            print(f"Skipping {s3_path}")
+            return
+        raise error
 
     local_path = STORE_PATH.joinpath(destination, *path)
     local_path.mkdir(parents=True, exist_ok=True)
@@ -91,4 +134,4 @@ def date_range(start_date: datetime.date, end_date: datetime.date):
 
 if __name__ == "__main__":
     logging.basicConfig(level=env.str("LOG_LEVEL", "DEBUG"))
-    monthly()
+    load_from_archive()


### PR DESCRIPTION
## Description

Part of #120.

Adds a "daily" sync type to "load_from_archive.py" so that results from previous daily runs can be re-used during re-processing. Specifically, the MCIP data that comes from the setup-wrf/run-wrf.sh script.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`

## Notes
