### PR TITLE
Improving bias correction

### DIFF
--- a/changelog/129.improvement.md
+++ b/changelog/129.improvement.md
@@ -1,0 +1,1 @@
+Improving bias correction

--- a/scripts/cmaq_preprocess/make_template.py
+++ b/scripts/cmaq_preprocess/make_template.py
@@ -86,7 +86,7 @@ if str(cmaq_config.sense_emis_lays).lower() == "template":
 # clear fwd and bwd logs from previous runs to prevent a log write error
 cmaq_handle.wipeout_fwd()
 # disable clearing of bwd working folder as this may be the cause of #121
-#cmaq_handle.wipeout_bwd()
+cmaq_handle.wipeout_bwd()
 
 # generate sample files by running 1 day of cmaq (fwd & bwd)
 cmaq_handle.run_fwd_single(date_defn.start_date, is_first=True)

--- a/scripts/docker-e2e-daily.sh
+++ b/scripts/docker-e2e-daily.sh
@@ -109,11 +109,6 @@ docker run --name="e2e-daily-obs_preprocess-process_tropomi" --rm \
   --env-file "$ENV_FILE" -v "$DATA_ROOT":/opt/project/data \
   openmethane bash scripts/obs_preprocess/process_tropomi.sh
 
-# JobName: cmaq_preprocess-bias_correct
-docker run --name="e2e-daily-cmaq_preprocess-bias_correct" --rm \
-  --env-file "$ENV_FILE" -v "$DATA_ROOT":/opt/project/data \
-  openmethane python scripts/cmaq_preprocess/bias_correct_cams.py
-
 # JobName: fourdvar-daily
 docker run --name="e2e-daily-fourdvar-daily" --rm \
   --env-file "$ENV_FILE" -v "$DATA_ROOT":/opt/project/data \

--- a/src/cmaq_preprocess/read_config_cmaq.py
+++ b/src/cmaq_preprocess/read_config_cmaq.py
@@ -234,7 +234,7 @@ def load_config_from_env(**overrides: typing.Any) -> CMAQConfig:
             "bconRun": {"path": root_dir / "templates" / "cmaq_preprocess/run.bcon"},
             "iconRun": {"path": root_dir / "templates" / "cmaq_preprocess/run.icon"},
         },
-        cams_to_cmaq_bias=env.float("CAMS_TO_CMAQ_BIAS", 1.838 - 1.771),
+        cams_to_cmaq_bias=env.float("CAMS_TO_CMAQ_BIAS", 0.0),
         boundary_trim=env.int("BOUNDARY_TRIM", 5),
     )
 

--- a/tests/unit/obs_preprocess/test_read_config/config_docker-test.yml
+++ b/tests/unit/obs_preprocess/test_read_config/config_docker-test.yml
@@ -1,5 +1,5 @@
 boundary_trim: 1
-cams_to_cmaq_bias: 0.06700000000000017
+cams_to_cmaq_bias: 0.0
 cmaq_source_dir: /opt/cmaq/CMAQv5.0.2_notpollen
 ctm_dir: /opt/project/tests/test-data/cmaq
 domain:

--- a/tests/unit/obs_preprocess/test_read_config/config_docker.yml
+++ b/tests/unit/obs_preprocess/test_read_config/config_docker.yml
@@ -1,5 +1,5 @@
 boundary_trim: 5
-cams_to_cmaq_bias: 0.06700000000000017
+cams_to_cmaq_bias: 0.0
 cmaq_source_dir: /opt/cmaq/CMAQv5.0.2_notpollen
 ctm_dir: /opt/project/data/cmaq
 domain:

--- a/tests/unit/obs_preprocess/test_read_config/config_nci-test.yml
+++ b/tests/unit/obs_preprocess/test_read_config/config_nci-test.yml
@@ -1,5 +1,5 @@
 boundary_trim: 1
-cams_to_cmaq_bias: 0.06700000000000017
+cams_to_cmaq_bias: 0.0
 cmaq_source_dir: /home/563/sa6589/CMAQv5.0.2_notpollen
 ctm_dir: /home/563/pjr563/openmethane-test/openmethane/tests/test-data/cmaq
 domain:

--- a/tests/unit/obs_preprocess/test_read_config/config_nci.yml
+++ b/tests/unit/obs_preprocess/test_read_config/config_nci.yml
@@ -1,5 +1,5 @@
 boundary_trim: 5
-cams_to_cmaq_bias: 0.06700000000000017
+cams_to_cmaq_bias: 0.0
 cmaq_source_dir: /home/563/sa6589/CMAQv5.0.2_notpollen
 ctm_dir: '{HOME}/scratch/openmethane-beta/run-py4dvar/cmaq'
 domain:


### PR DESCRIPTION
## Description
Previously bias correction between CAMS inputs and TROPOMI occurred in
two places and also suppressed day-to-day differences in boundary
conditions. This version avoids any bias correction in the daily runs.
Bias correction is now carried out once in the monthly run with the
same correction applied to the iCon and all the bCons. 
## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`

## Notes
This means that actual concentrations in the forward run of the dailys
are offset from reality by a fixed amount. This is ok provided we use
some difference metric like local enhancement to calculate alerts.