### PR TITLE
Add wrf folder to list of restored daily paths in load_from_archive.py

### DIFF
--- a/changelog/130.fix.md
+++ b/changelog/130.fix.md
@@ -1,0 +1,1 @@
+Fix bug in cmaq_preprocess when mcip folder is loaded from archive without wrf folder

--- a/scripts/load_from_archive.py
+++ b/scripts/load_from_archive.py
@@ -76,6 +76,7 @@ def daily():
     likely to change.
     """
     for path in [
+        ["wrf"],
         ["mcip"],
     ]:
         _sync_daily_directory(START_DATE, path, pathlib.Path('.'), allow_missing=True)


### PR DESCRIPTION
## Description

The `cmaq_preprocess/setup_for_cmaq.py` script appears to fail if the `mcip` folder is present but not the `wrf` folder:

```
  File "/opt/project/scripts/cmaq_preprocess/setup_for_cmaq.py", line 35, in main
    setup_for_cmaq(config)
  File "/opt/project/scripts/cmaq_preprocess/setup_for_cmaq.py", line 57, in setup_for_cmaq
    run_mcip(
  File "/opt/project/src/cmaq_preprocess/mcip.py", line 110, in run_mcip
    raise AssertionError(f"WRF output {src} not found")
AssertionError: WRF output /opt/project/data/aust10km/2023-01-01-34c0a915-534f-4570-9c9a-c5bcdd58ff71/wrf/aust10km/2023010100/WRFOUT_d01_2023-01-01T0000Z.nc not found
```

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
