### PR TITLE
Fix incorrect s3 path construction in `util/archive.py`

### DIFF
--- a/changelog/137.fix.md
+++ b/changelog/137.fix.md
@@ -1,0 +1,1 @@
+- Fix incorrect s3 path if TARGET_BUCKET doesn't contain a trailing slash

--- a/src/util/archive.py
+++ b/src/util/archive.py
@@ -64,7 +64,7 @@ def daily(
         _s3_sync_fetch(daily_root + remote_path, local_path.joinpath(remote_path), allow_missing=True)
 
     # fetch the alerts_baseline file for creating alerts
-    _s3_object_fetch(daily_s3_bucket + str(alerts_baseline_remote), local_path)
+    _s3_object_fetch("/".join([daily_s3_bucket.rstrip("/"), str(alerts_baseline_remote)]), local_path)
 
 
 def baseline(


### PR DESCRIPTION
## Description

This file features multiple ways to construct paths, and doesn't enforce whether the configured `TARGET_BUCKET` has a trailing slash or not. This will construct the correct path regardless of whether `TARGET_BUCKET` contains a trailing slash or not.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
