### PR TITLE
correcting alerts calculation over multiple days

### DIFF
--- a/changelog/140.fix.md
+++ b/changelog/140.fix.md
@@ -1,0 +1,1 @@
+- Fix alerts baseline not handling NaN values

--- a/scripts/alerts/alerts_baseline.py
+++ b/scripts/alerts/alerts_baseline.py
@@ -31,6 +31,7 @@ def main():
     sim_file_template = env.str('ALERTS_SIM_FILE_TEMPLATE', default='simulobs.pic.gz')
     near_threshold = env.float('ALERTS_NEAR_THRESHOLD', 0.2)
     far_threshold = env.float('ALERTS_FAR_THRESHOLD', 1.0)
+    count_threshold = env.int('ALERTS_COUNT_THRESHOLD', 1)
     output_file = env.str('ALERTS_BASELINE_FILE', default='alerts_baseline.nc')
 
     alerts.create_alerts_baseline(
@@ -40,6 +41,7 @@ def main():
         sim_file_template = sim_file_template,
         near_threshold = near_threshold,
         far_threshold = far_threshold,
+        count_threshold = count_threshold,
         output_file = output_file,
     )
 


### PR DESCRIPTION
-------

## Description
We are using np.nan to flag values where an alert cannot be
calculated. Thus np.mean would return np.nan if *any* values in an
alerts baseline calculation for a given point were np.nan. Here we
switch to using np.nanmean but also record the number of observations
that go into each baseline. this will allow later calculations where
we will calculate baselines from multiple months without needing to
recalculate for each month. 

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
- probably need to adjust period_start and period_end to point to
  whole days
  - it's possible that ALERTS_COUNT_THRESHOLD will only be used in
  calculating alerts, not baseline