### PR TITLE
calculating alerts against new baseline calculation

### DIFF
--- a/changelog/141.improvement.md
+++ b/changelog/141.improvement.md
@@ -1,0 +1,1 @@
+calculating alerts with new baseline methodology

--- a/scripts/alerts/alerts_baseline.py
+++ b/scripts/alerts/alerts_baseline.py
@@ -31,7 +31,6 @@ def main():
     sim_file_template = env.str('ALERTS_SIM_FILE_TEMPLATE', default='simulobs.pic.gz')
     near_threshold = env.float('ALERTS_NEAR_THRESHOLD', 0.2)
     far_threshold = env.float('ALERTS_FAR_THRESHOLD', 1.0)
-    count_threshold = env.int('ALERTS_COUNT_THRESHOLD', 1)
     output_file = env.str('ALERTS_BASELINE_FILE', default='alerts_baseline.nc')
 
     alerts.create_alerts_baseline(
@@ -41,7 +40,6 @@ def main():
         sim_file_template = sim_file_template,
         near_threshold = near_threshold,
         far_threshold = far_threshold,
-        count_threshold = count_threshold,
         output_file = output_file,
     )
 

--- a/scripts/alerts/create_alerts.py
+++ b/scripts/alerts/create_alerts.py
@@ -27,8 +27,8 @@ def main():
     obs_file_template = env.str('ALERTS_OBS_FILE_TEMPLATE', default='input/test_obs.pic.gz')
     sim_file_template = env.str('ALERTS_SIM_FILE_TEMPLATE', default='simulobs.pic.gz')
     output_file = env.str('ALERTS_OUTPUT_FILE', default='alerts.nc')
-    alerts_threshold = env.float( 'ALERTS_THRESHOLD', default=0.0)
-    significance_threshold = env.float( 'SIGNIFICANCE_THRESHOLD', default=2.0)
+    alerts_threshold = env.float( 'ALERTS_THRESHOLD', default=5.0)
+    significance_threshold = env.float( 'SIGNIFICANCE_THRESHOLD', default=3.0)
     count_threshold = env.int("ALERTS_COUNT_THRESHOLD", 30)
 
     alerts.create_alerts(

--- a/scripts/alerts/create_alerts.py
+++ b/scripts/alerts/create_alerts.py
@@ -29,6 +29,7 @@ def main():
     output_file = env.str('ALERTS_OUTPUT_FILE', default='alerts.nc')
     alerts_threshold = env.float( 'ALERTS_THRESHOLD', default=0.0)
     significance_threshold = env.float( 'SIGNIFICANCE_THRESHOLD', default=2.0)
+    count_threshold = env.int("ALERTS_COUNT_THRESHOLD", 30)
 
     alerts.create_alerts(
         baseline_file = baseline_file,
@@ -38,6 +39,7 @@ def main():
         output_file = output_file,
         alerts_threshold = alerts_threshold,
         significance_threshold=significance_threshold,
+        count_threshold = count_threshold,
     )
 
     

--- a/src/postproc/alerts.py
+++ b/src/postproc/alerts.py
@@ -337,6 +337,9 @@ def create_alerts(
             "YCELL": alerts_baseline_ds.YCELL,
             "alerts_near_threshold": alerts_baseline_ds.alerts_near_threshold,
             "alerts_far_threshold": alerts_baseline_ds.alerts_far_threshold,
+            "alerts_threshold": alerts_threshold,
+            "alerts_significance_threshold": significance_threshold,
+            "alerts_count_threshold": count_threshold,
 
             # common
             "title": "Open Methane daily methane alerts",


### PR DESCRIPTION
## Description
the change in the calculation of the alerts baseline requires a change
in the calculation of alerts themselves. nan is no longer used as the
main test for the baseline though it is still used in the local
enhancement itself. Instead a baseline_count variable lists the number
of valid enhancement calculated in the baseline
## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`

## Notes