### PR TITLE
Fix parallel file reads in tropomi preprocessing

### DIFF
--- a/changelog/146.fix.md
+++ b/changelog/146.fix.md
@@ -1,0 +1,1 @@
+- Exit obs_preprocess with a failure when an exception occurs

--- a/changelog/146.fix.md
+++ b/changelog/146.fix.md
@@ -1,1 +1,1 @@
-- Exit obs_preprocess with a failure when an exception occurs
+- Fix multiple threads reading METCRO2D file simultaneously

--- a/scripts/obs_preprocess/tropomi_methane_preprocess.py
+++ b/scripts/obs_preprocess/tropomi_methane_preprocess.py
@@ -363,6 +363,7 @@ def run_tropomi_preprocess(source, output_file, qa_cutoff, max_process_time):
         except Exception:
             # Ignore all observations in that file
             logger.exception(f"Failed to process file: {fname}. Skipping")
+            raise
 
     print(f"found {n_valid_obs} valid soundings from {n_total_obs} possible")
     if len(obs_list) > 0:

--- a/scripts/obs_preprocess/tropomi_methane_preprocess.py
+++ b/scripts/obs_preprocess/tropomi_methane_preprocess.py
@@ -332,6 +332,11 @@ def run_tropomi_preprocess(source, output_file, qa_cutoff, max_process_time):
     """
     model_grid = ModelSpace.create_from_fourdvar()
 
+    # load psurf file pre-emptively so multiple threads dont attempt
+    # simultaneous reads
+    start_date = int(date_defn.start_date.strftime("%Y%m%d"))
+    model_grid.update_psurf(start_date)
+
     file_list = sorted([os.path.realpath(f) for f in glob.glob(source)])
 
     obs_list = []

--- a/src/obs_preprocess/model_space.py
+++ b/src/obs_preprocess/model_space.py
@@ -25,6 +25,7 @@ from netCDF4 import Dataset
 from fourdvar.params import cmaq_config, date_defn, template_defn
 from fourdvar.util import date_handle
 from obs_preprocess.ray_trace import Grid
+from util.logger import get_logger
 
 
 # convert HHMMSS into sec
@@ -78,6 +79,8 @@ class ModelSpace:
         CONC = path to any concentration file output by CMAQ
         date_range = [ start_date, end_date ] (as datetime objects).
         """
+        self.logger = get_logger(__name__)
+
         # read netCDF files
         self.gridmeta = {}
         with Dataset(METCRO3D, "r") as f:
@@ -212,6 +215,8 @@ class ModelSpace:
         row = target_coord[3]
         col = target_coord[4]
         if date != self.psurf_date:
+            if self.psurf_date is not None:
+                self.logger.warning("update_psurf is not thread-safe and may cause issues reading METCRO2D")
             self.update_psurf(date)
         vgbot = self.psurf_arr[time, row, col]
         vglvl = np.array(self.gridmeta["VGLVLS"])


### PR DESCRIPTION
## Description

This PR includes two major changes:
1. avoiding simultaneous reads of the METRCO2D file during threaded processing
2. return non-zero exit code when errors occur during obs processing

### Avoiding simultaneous reads of the METRCO2D file during threaded processing

The ModelSpace class, which is used to transform tropomi observations into our grid space, reads both the METCRO3D and METCRO2D while transforming an observation into grid space. The METCRO3D file is read when the class is instantiated, but METCRO2D isn't read until it's needed in `get_pressure_bounds`.

The `tropomi_methane_preprocess.py` script uses multiple threads to transform potentially large lists of observations into grid space. It's dangerous for multiple threads to attempt reading the same NetCDF file simultaneously, so the ModelSpace class is instantiated before threading starts and passed to each thread. However, since the METCRO2D file is loaded late, this causes a potential issue if multiple threads try to read the file at the same time.

By manually calling `update_psurf` preemptively prior to threading, hopefully this can be avoided.

### Return non-zero exit code when errors occur during obs processing

Effectively all exceptions during obs preprocessing are currently ignored. This was done intentionally in the past due to occasional corruption in tropomi data, but the exception matching doesn't target a specific exception type, leading to all errors being caught, logged and ignored.

The parallel reading issue (see above) is causing preprocessing to fail in prod workflows, but the workflow marks the job successful because it exits with a 0 status code after the exception is caught. This change will cause the script to exit with a non-0 status, so the workflow marks the job as failed. This will allow us to redrive the workflow execution and possibly recover from the failure.

In the worst case, it will properly alert us when this task has failed to process observations so that we can diagnose and fix any root causes.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
