### PR TITLE
Adding filter for SWIR aerosol optical depth and storing SWIR aod in obs output

### DIFF
--- a/changelog/148.improvement.md
+++ b/changelog/148.improvement.md
@@ -1,0 +1,1 @@
+Adding SWIR aod filter and storing SWIR aod in obs output

--- a/scripts/obs_preprocess/tropomi_methane_preprocess.py
+++ b/scripts/obs_preprocess/tropomi_methane_preprocess.py
@@ -350,7 +350,7 @@ def process_observations(
     help="Maximum time to process each observation in seconds. Default is 5 seconds",
     default=5,
 )
-def run_tropomi_preprocess(source, output_file, qa_cutoff, swir_albedo_cutoff, max_process_time):
+def run_tropomi_preprocess(source, output_file, qa_cutoff, swir_albedo_cutoff, swir_aod_cutoff, max_process_time):
     """
     Process TROPOMI data to create a set of observations for use in the fourdvar system.
     """
@@ -384,6 +384,7 @@ def run_tropomi_preprocess(source, output_file, qa_cutoff, swir_albedo_cutoff, m
                     ds,
                     qa_cutoff=qa_cutoff,
                     swir_albedo_cutoff = swir_albedo_cutoff,
+                    swir_aod_cutoff = swir_aod_cutoff, 
                     max_process_time=max_process_time,
                 )
 

--- a/src/obs_preprocess/obsESA_defn.py
+++ b/src/obs_preprocess/obsESA_defn.py
@@ -66,6 +66,7 @@ class ObsSRON(ObsMultiRay):
         newobs.out_dict["time"] = kwargs["time"]
         newobs.out_dict["qa_value"] = kwargs["qa_value"]
         newobs.out_dict["surface_albedo_SWIR"] = kwargs["surface_albedo_SWIR"]
+        newobs.out_dict["aerosol_aod_SWIR"] = kwargs["aerosol_aod_SWIR"]
         newobs.out_dict["latitude_corners"] = kwargs["latitude_corners"]
         newobs.out_dict["longitude_corners"] = kwargs["longitude_corners"]
         newobs.out_dict["latitude_center"] = kwargs["latitude_center"]

--- a/tests/integration/obs_preprocess/test_tropomi_methane_preprocess/tropomi_methane_obs.yml
+++ b/tests/integration/obs_preprocess/test_tropomi_methane_preprocess/tropomi_methane_obs.yml
@@ -4,6 +4,7 @@
 - time
 - qa_value
 - surface_albedo_SWIR
+- aerosol_aod_SWIR
 - latitude_corners
 - longitude_corners
 - latitude_center


### PR DESCRIPTION
-------

## Description
Shortwave infrared (SWIR) aerosols can significantly bias methane
retrievals. This change discards any soundings with SWIR aerosol
optical depth > some threshold, currently 0.13.
## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes