### PR TITLE
Remove excessive logging in alerts processing

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -141,7 +141,7 @@ jobs:
           python -m pytest -r a -v tests/integration/cmaq_preprocess tests/integration/obs_preprocess
 
   test-e2e:
-    timeout-minutes: 10
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     needs: build
     permissions:

--- a/changelog/151.trivial.md
+++ b/changelog/151.trivial.md
@@ -1,0 +1,1 @@
+- Remove excessive logging in alerts processing

--- a/src/postproc/alerts.py
+++ b/src/postproc/alerts.py
@@ -563,7 +563,6 @@ def map_enhance(lat, lon, land_mask, concs, nearThreshold, farThreshold): # noqa
 
 def point_enhance(val):
     i, j, lat, lon, land_mask, concs, nearThreshold, farThreshold = val
-    logger.debug(f"[Cell ({i}, {j})] Calculating point enhancement")
 
     if land_mask[i, j] < 0.5:  # ocean point
         return i, j, np.nan, np.nan


### PR DESCRIPTION
## Description

Logging was added to alerts processing, which at the time wasn't working and had no log output to indicate where the failure was occurring. However, some of the alerts logging runs on every point calculation within every input file, leading to excessive noise in the logs and adding difficulty in extracting meaningful detail.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
