### PR TITLE
Fix `long_name` attribute on CH4 and prior_CH4 NetCDF variables

### DIFF
--- a/changelog/152.fix.md
+++ b/changelog/152.fix.md
@@ -1,0 +1,1 @@
+- Fix `long_name` attributes on CH4 and prior_CH4 variables in results file

--- a/src/postproc/posterior_emissions_postprocess.py
+++ b/src/postproc/posterior_emissions_postprocess.py
@@ -127,7 +127,7 @@ def posterior_emissions_postprocess(
                 {
                     "units": "kg/m**2/s",
                     "standard_name": "emissions",
-                    "long_name": "expected flux of methane based on public data (prior)",
+                    "long_name": "estimated flux of methane based on observations (posterior)",
                 },
             ),
             # expected emissions (prior averaged over period)
@@ -137,7 +137,7 @@ def posterior_emissions_postprocess(
                 {
                     "units": "kg/m**2/s",
                     "standard_name": "emissions",
-                    "long_name": "estimated flux of methane based on observations (posterior)",
+                    "long_name": "expected flux of methane based on public data (prior)",
                 },
             ),
         },


### PR DESCRIPTION

## Description

These were applied to the wrong variable, which might result in confusion in the future.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
