### PR TITLE
Skip processing tropomi files with no methane data

### DIFF
--- a/changelog/154.fix.md
+++ b/changelog/154.fix.md
@@ -1,0 +1,1 @@
+- Skip tropomi files with no `methane_mixing_ratio_bias_corrected` data

--- a/src/util/errors/InvalidInputException.py
+++ b/src/util/errors/InvalidInputException.py
@@ -1,0 +1,3 @@
+
+class InvalidInputException(Exception):
+    pass


### PR DESCRIPTION
## Description

Resolves #153 .

This restores previous functionality for skipping bad files, but only under known conditions.

Where the previous solution silently swallowed all errors during process_file, this solution raises a custom error for known incorrect conditions. Unexpected errors will be raised so they can be examined and fixed.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
