### PR TITLE
Fix empty `STORE_PATH` when archive.py is run via eventbridge

### DIFF
--- a/changelog/155.fix.md
+++ b/changelog/155.fix.md
@@ -1,0 +1,1 @@
+- Fix archive.py store path when run after a workflow failure


### PR DESCRIPTION

## Description

The previous changes to source STORE_PATH from env variable in #133 assumed that archive.py would only be called from a workflow step, and failed to understand why the path was being re-constructed in the first place.  The archive script is also called when a workflow fails, but in this context will not have STORE_PATH set.

Failed jobs have been archiving the entire EFS aust10km folder, leading to a large amount of duplication and partial archives due to timeouts.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
