### PR TITLE
Add a 'baseline' archive type for the new baseline workflow

### DIFF
--- a/changelog/156.improvement.md
+++ b/changelog/156.improvement.md
@@ -1,0 +1,1 @@
+- Update archive scripts to support new 'baseline' workflow

--- a/scripts/archive.py
+++ b/scripts/archive.py
@@ -95,10 +95,21 @@ def main():
         logger.debug(f"Archiving {config.run_type} run to {target_path}")
         archive_dir(store_path, config.target_bucket, target_path)
 
-        # on success for a monthly run, replace the alerts_baseline.nc for the domain
-        # with the result from this run
-        # TODO: should this check that alerts_baseline.nc is more recent than existing?
-        if config.alerts_baseline_file and config.alerts_baseline_file.exists():
+    elif config.run_type == "baseline":
+        # archive the entire run to the private results bucket
+        # at a path like: aust10km/baseline/2023/01
+        target_path = pathlib.Path(
+            config.domain_name, "baseline",
+            f"{config.start_date.year:04}", f"{config.start_date.month:02}"
+        )
+        logger.debug(f"Archiving {config.run_type} run to {target_path}")
+        archive_dir(store_path, config.target_bucket, target_path)
+
+        # if the script is configured with alerts_baseline_remote, archive the
+        # result there. this is typically used to provide a new baseline for
+        # daily alerts generated within the daily workflow.
+        alerts_baseline_file = pathlib.Path(store_path, "alerts_baseline.nc")
+        if config.alerts_baseline_remote and alerts_baseline_file.exists():
             logger.debug(f"Archiving {config.alerts_baseline_file} to {config.alerts_baseline_remote}")
             archive_file(config.alerts_baseline_file, config.target_bucket, config.alerts_baseline_remote)
 

--- a/scripts/archive.py
+++ b/scripts/archive.py
@@ -56,13 +56,13 @@ def main():
         )
 
     if config.test:
-        archive_dir(store_path, config.target_bucket, pathlib.Path("tests", config.execution_id))
+        archive_dir(store_path, config.archive_bucket, pathlib.Path("tests", config.execution_id))
         return
 
     # failed executions should not archive to daily/monthly results locations
     if not config.success:
         target_path = pathlib.Path(config.domain_name, "failed", config.execution_id)
-        archive_dir(store_path, config.target_bucket, target_path)
+        archive_dir(store_path, config.archive_bucket, target_path)
         logger.info(f"Not deleting {store_path} for failed run - clean up manually.")
         return
 
@@ -74,16 +74,16 @@ def main():
             f"{config.start_date.year:04}", f"{config.start_date.month:02}", f"{config.start_date.day:02}"
         )
         logger.debug(f"Archiving {config.run_type} run to {target_path}")
-        archive_dir(store_path, config.target_bucket, target_path)
+        archive_dir(store_path, config.archive_bucket, target_path)
 
         # a small subset of results should be uploaded to the public data store
-        if config.target_bucket_reduced:
+        if config.public_bucket:
             target_public_path = pathlib.Path(
                 "alerts", "daily", config.domain_name,
                 f"{config.start_date.year:04}", f"{config.start_date.month:02}", f"{config.start_date.day:02}"
             )
             logger.debug(f"Archiving {config.run_type} run to {target_path} in public data store.")
-            archive_file(store_path / "alerts.nc", config.target_bucket_reduced, target_public_path / "alerts.nc")
+            archive_file(store_path / "alerts.nc", config.public_bucket, target_public_path / "alerts.nc")
 
     elif config.run_type == "monthly":
         # archive the entire run to the private results bucket
@@ -93,7 +93,7 @@ def main():
             f"{config.start_date.year:04}", f"{config.start_date.month:02}"
         )
         logger.debug(f"Archiving {config.run_type} run to {target_path}")
-        archive_dir(store_path, config.target_bucket, target_path)
+        archive_dir(store_path, config.archive_bucket, target_path)
 
     elif config.run_type == "baseline":
         # archive the entire run to the private results bucket
@@ -103,7 +103,7 @@ def main():
             f"{config.start_date.year:04}", f"{config.start_date.month:02}"
         )
         logger.debug(f"Archiving {config.run_type} run to {target_path}")
-        archive_dir(store_path, config.target_bucket, target_path)
+        archive_dir(store_path, config.archive_bucket, target_path)
 
         # if the script is configured with alerts_baseline_remote, archive the
         # result there. this is typically used to provide a new baseline for
@@ -111,7 +111,7 @@ def main():
         alerts_baseline_file = pathlib.Path(store_path, "alerts_baseline.nc")
         if config.alerts_baseline_remote and alerts_baseline_file.exists():
             logger.debug(f"Archiving {config.alerts_baseline_file} to {config.alerts_baseline_remote}")
-            archive_file(config.alerts_baseline_file, config.target_bucket, config.alerts_baseline_remote)
+            archive_file(config.alerts_baseline_file, config.archive_bucket, config.alerts_baseline_remote)
 
     else:
         raise ValueError(f"Unknown config.run_type={config.run_type!r}")
@@ -126,8 +126,8 @@ def main():
 @dataclass
 class Config:
     store_path: pathlib.Path | None
-    target_bucket: str
-    target_bucket_reduced: str
+    archive_bucket: str
+    public_bucket: str
     domain_name: str
     start_date_raw: str
     start_date: datetime.date
@@ -162,8 +162,8 @@ class Config:
             domain_name = env.str("DOMAIN_NAME")
             store_path = env.path("STORE_PATH")
 
-        target_bucket = env.str("TARGET_BUCKET")
-        target_bucket_reduced = env.str("TARGET_BUCKET_REDUCED", "")
+        archive_bucket = env.str("ARCHIVE_BUCKET")
+        public_bucket = env.str("PUBLIC_BUCKET", "")
         run_type = env.str("RUN_TYPE")
         success = env.bool("SUCCESS")
         test = env.bool("TEST", False)
@@ -174,8 +174,8 @@ class Config:
 
         return cls(
             store_path=store_path,
-            target_bucket=target_bucket,
-            target_bucket_reduced=target_bucket_reduced,
+            archive_bucket=archive_bucket,
+            public_bucket=public_bucket,
             domain_name=domain_name,
             start_date_raw=start_date_raw,
             start_date=start_date,
@@ -191,7 +191,8 @@ class Config:
 
     def dump(self, store_path: pathlib.Path, prefix: str):
         logger.debug(f"""Configuration:
-target_bucket  = {self.target_bucket!r}
+archive_bucket  = {self.archive_bucket!r}
+public_bucket  = {self.public_bucket!r}
 domain_name    = {self.domain_name!r}
 start_date_raw = {self.start_date_raw!r}
 start_date     = {self.start_date}

--- a/scripts/load_from_archive.py
+++ b/scripts/load_from_archive.py
@@ -21,12 +21,13 @@ import click
 from fourdvar.env import env
 from util import archive
 
-TARGET_BUCKET = env.str("TARGET_BUCKET", "s3://test-bucket")
+ARCHIVE_BUCKET = env.str("ARCHIVE_BUCKET", "s3://test-bucket")
+PUBLIC_BUCKET = env.str("PUBLIC_BUCKET", "s3://public-bucket")
 DOMAIN_NAME = env.str("DOMAIN_NAME")
+DOMAIN_VERSION = env.str("DOMAIN_VERSION")
 STORE_PATH: pathlib.Path = env.path("STORE_PATH")
 START_DATE = env.date("START_DATE")
 END_DATE = env.date("END_DATE")
-BASELINE_LENGTH_DAYS = env.int("BASELINE_LENGTH_DAYS", 365)
 ALERTS_BASELINE_REMOTE = env.path("ALERTS_BASELINE_REMOTE", "")
 
 
@@ -43,7 +44,7 @@ def load_from_archive(sync: str = "monthly"):
     match sync:
         case "daily":
             archive.daily(
-                daily_s3_bucket=TARGET_BUCKET,
+                daily_s3_bucket=ARCHIVE_BUCKET,
                 start_date=START_DATE,
                 domain_name=DOMAIN_NAME,
                 local_path=STORE_PATH,
@@ -52,17 +53,19 @@ def load_from_archive(sync: str = "monthly"):
 
         case "baseline":
             archive.baseline(
-                daily_s3_bucket=TARGET_BUCKET,
+                daily_s3_bucket=ARCHIVE_BUCKET,
+                public_s3_bucket=PUBLIC_BUCKET,
+                start_date=START_DATE,
                 end_date=END_DATE,
                 domain_name=DOMAIN_NAME,
+                domain_version=DOMAIN_VERSION,
                 local_path=STORE_PATH,
-                baseline_length_days=BASELINE_LENGTH_DAYS,
             )
 
         # default case catches "monthly" as well
         case _:
             archive.monthly(
-                daily_s3_bucket=TARGET_BUCKET,
+                daily_s3_bucket=ARCHIVE_BUCKET,
                 start_date=START_DATE,
                 end_date=END_DATE,
                 domain_name=DOMAIN_NAME,

--- a/src/util/archive.py
+++ b/src/util/archive.py
@@ -72,7 +72,7 @@ def daily(
 
     # fetch the alerts_baseline file for creating alerts
     _s3_object_fetch(
-        _get_s3_url(daily_s3_bucket, alerts_baseline_remote), local_path
+        _format_s3_url(daily_s3_bucket, alerts_baseline_remote), local_path
     )
 
 
@@ -118,7 +118,7 @@ def baseline(
 def fetch_domain(s3_bucket_name: str, domain_name: str, domain_version: str, output_path: pathlib.Path):
     domain_filename = f"domain_{domain_version}.d01.nc"
 
-    s3_url = _get_s3_url(
+    s3_url = _format_s3_url(
         s3_bucket_name=s3_bucket_name,
         s3_path=pathlib.Path('domains', domain_name, domain_version, domain_filename),
     )
@@ -131,7 +131,7 @@ def fetch_domain(s3_bucket_name: str, domain_name: str, domain_version: str, out
     )
 
 
-def _get_s3_url(s3_bucket_name: str, s3_path: str | pathlib.Path = None) -> str:
+def _format_s3_url(s3_bucket_name: str, s3_path: str | pathlib.Path = None) -> str:
     s3_bucket = (s3_bucket_name if s3_bucket_name.startswith("s3://") else f"s3://{s3_bucket_name}").rstrip("/")
     if s3_path is None:
         return s3_bucket
@@ -148,7 +148,7 @@ def _get_daily_archive_path(s3_bucket_name: str, domain_name: str, date: datetim
         f"{date.day:02}",
     )
 
-    s3_url = _get_s3_url(s3_bucket_name, '/'.join(daily_archive_path))
+    s3_url = _format_s3_url(s3_bucket_name, '/'.join(daily_archive_path))
 
     return s3_url + "/"  # S3 directory paths must end with a slash
 

--- a/tests/unit/util/test_archive.py
+++ b/tests/unit/util/test_archive.py
@@ -1,0 +1,134 @@
+"""Tests various archiving helpers."""
+import datetime
+import pathlib
+from unittest.mock import call, patch
+
+from util.archive import baseline, daily, fetch_domain, monthly
+
+@patch('subprocess.run')
+def test_monthly(mockRun, tmp_path):
+    # initiate load archive for a 3 day monthly run
+    monthly(
+        "test-bucket-name",
+        datetime.date(2022, 10, 29),
+        datetime.date(2022, 10, 31),
+        "test-domain",
+        tmp_path,
+    )
+
+    # monthly run from 2022-10-29 to 2022-10-31 will fetch input, cmaq and mcip folders for each day
+    for date in ['2022/10/29', '2022/10/30', '2022/10/31']:
+        for path in ['input', 'cmaq', 'mcip']:
+            # checks if s3 path exists with 'aws ls' before fetching with 'aws sync'
+            mockRun.assert_has_calls([
+                call([
+                    "aws", "s3", "ls", f"s3://test-bucket-name/test-domain/daily/{date}/{path}",
+                ], check=True, capture_output=False),
+                call([
+                    "aws", "s3", "sync", "--no-progress", f"s3://test-bucket-name/test-domain/daily/{date}/{path}",
+                    str(tmp_path / f"test-domain/daily/{date}/{path}"),
+                ], check=True, capture_output=True, text=True),
+            ])
+
+            mockRun.assert_has_calls([
+                call([
+                    "aws", "s3", "ls", f"s3://test-bucket-name/test-domain/daily/{date}/simulobs.pic.gz",
+                ], check=True, capture_output=False),
+                call([
+                    "aws", "s3", "cp", "--no-progress", f"s3://test-bucket-name/test-domain/daily/{date}/simulobs.pic.gz",
+                    str(tmp_path / f"test-domain/daily/{date}"),
+                ], check=True, capture_output=True, text=True),
+            ])
+
+
+@patch('subprocess.run')
+def test_daily(mockRun, tmp_path):
+    # initiate load archive for a daily run
+    daily(
+        "test-bucket-name",
+        datetime.date(2022, 10, 29),
+        "test-domain",
+        tmp_path,
+        pathlib.Path("alerts_baseline.nc"),
+    )
+
+    # daily run will fetch wrf and mcip folders for each day
+    for path in ['wrf', 'mcip']:
+        # checks if s3 path exists with 'aws ls' before fetching with 'aws sync'
+        mockRun.assert_has_calls([
+            call([
+                "aws", "s3", "ls", f"s3://test-bucket-name/test-domain/daily/2022/10/29/{path}",
+            ], check=True, capture_output=False),
+            call([
+                "aws", "s3", "sync", "--no-progress", f"s3://test-bucket-name/test-domain/daily/2022/10/29/{path}",
+                str(tmp_path / path),
+            ], check=True, capture_output=True, text=True),
+        ])
+
+        mockRun.assert_called_with([
+            "aws", "s3", "cp", "--no-progress",
+            "s3://test-bucket-name/alerts_baseline.nc",
+            str(tmp_path),
+        ], check=True, capture_output=True, text=True)
+
+
+
+@patch('subprocess.run')
+def test_baseline(mockRun, tmp_path):
+    # initiate load archive for a 3 day baseline run
+    baseline(
+        "test-bucket-name",
+        "test-public-bucket",
+        datetime.date(2022, 10, 29),
+        datetime.date(2022, 10, 31),
+        "test-domain",
+        "v2",
+        tmp_path,
+    )
+
+    # baseline must fetch the domain
+    mockRun.assert_has_calls([
+        call([
+            "aws", "s3", "ls", "s3://test-public-bucket/domains/test-domain/v2/domain_v2.d01.nc",
+        ], check=True, capture_output=False),
+        call([
+            "aws", "s3", "cp", "--no-progress", "s3://test-public-bucket/domains/test-domain/v2/domain_v2.d01.nc",
+            str(tmp_path),
+        ], check=True, capture_output=True, text=True),
+    ])
+
+    # baseline run from 2022-10-29 to 2022-10-31 will fetch input, cmaq and mcip folders for each day
+    for date in ['2022/10/29', '2022/10/30', '2022/10/31']:
+        # checks if s3 path exists with 'aws ls' before fetching with 'aws sync'
+        mockRun.assert_has_calls([
+            call([
+                "aws", "s3", "ls", f"s3://test-bucket-name/test-domain/daily/{date}/input",
+            ], check=True, capture_output=False),
+            call([
+                "aws", "s3", "sync", "--no-progress",
+                "--exclude=*", "--include=test_obs.pic.gz",
+                f"s3://test-bucket-name/test-domain/daily/{date}/input",
+                str(tmp_path / f"test-domain/baseline/{date}/input"),
+            ], check=True, capture_output=True, text=True),
+        ])
+
+        mockRun.assert_has_calls([
+            call([
+                "aws", "s3", "ls", f"s3://test-bucket-name/test-domain/daily/{date}/simulobs.pic.gz",
+            ], check=True, capture_output=False),
+            call([
+                "aws", "s3", "cp", "--no-progress", f"s3://test-bucket-name/test-domain/daily/{date}/simulobs.pic.gz",
+                str(tmp_path / f"test-domain/baseline/{date}"),
+            ], check=True, capture_output=True, text=True),
+        ])
+
+
+@patch('subprocess.run')
+def test_fetch_domain(mockRun, tmp_path):
+    fetch_domain("test-bucket-name", "test-domain","v1", tmp_path)
+
+    mockRun.assert_called_with([
+        "aws", "s3", "cp", "--no-progress",
+        "s3://test-bucket-name/domains/test-domain/v1/domain_v1.d01.nc",
+        str(tmp_path),
+    ], check=True, capture_output=True, text=True)


### PR DESCRIPTION
## Description

This PR enables a new workflow in which the only task is to create a baseline from a range of daily results. Among the relevant changes:
- loading from archive has been updated for the monthly workflow, which will now generate a baseline solely from START_DATE to END_DATE
- loading from archive has been added for the baseline task, this now also operates from START_DATE to END_DATE
- saving to archive has been simplified, with some helper methods and unit tests
- the baseline archive script has a `ALERTS_SAVE_REFERENCE` env variable, which will overwrite the existing baseline for the domain in the S3 results bucket.

### Change of environment variables

Some environment variables for the archiving scripts have been changed to use more descriptive names:
- `TARGET_BUCKET` has been changed to `ARCHIVE_BUCKET`
  - when loading from archive, this is the bucket to load from
  - when saving to the archive, this is the bucket to upload files to
- `TARGET_BUCKET_REDUCED` has been changed to `PUBLIC_BUCKET`
  - this is where public results like daily alerts will be uploaded automatically for successful jobs
  - this is also where domain files will be fetched from

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
