### PR TITLE
setting non-neg emissions and configuring via environment

### DIFF
--- a/changelog/157.fix.md
+++ b/changelog/157.fix.md
@@ -1,0 +1,1 @@
+setting non-neg emissions and configuring via environment

--- a/src/fourdvar/_main_driver.py
+++ b/src/fourdvar/_main_driver.py
@@ -23,6 +23,7 @@ from fourdvar import user_driver
 from fourdvar._transform import transform
 from fourdvar.params import archive_defn, data_access
 from util.logger import get_logger
+from fourdvar.env import env
 
 logger = get_logger(__name__)
 
@@ -172,13 +173,16 @@ def get_answer():
     input: None
     output: None (user_driver.display should print/save output as desired).
     """
+    allow_negative_emissions = env.bool("ALLOW_NEGATIVE_EMISSIONS", False)
     # set up background unknowns
     bg_physical = user_driver.get_background()
     bg_unknown = transform(bg_physical, d.UnknownData)
 
     user_driver.setup()
     start_vector = bg_unknown.get_vector()
-    min_output = user_driver.minim(cost_func, gradient_func, start_vector)
+    min_output = user_driver.minim(cost_func, gradient_func, start_vector,
+                                   allow_negative_emissions = allow_negative_emissions,
+                                   physical_template = bg_physical)
     out_vector = min_output[0]
     out_unknown = d.UnknownData(out_vector)
     out_physical = transform(out_unknown, d.PhysicalData)

--- a/src/fourdvar/user_driver.py
+++ b/src/fourdvar/user_driver.py
@@ -127,7 +127,7 @@ def minim(cost_func, grad_func,
         species =physical_template.spcs
         if len(species) != 1:
             raise ValueError("bounds only works for one species")
-        len_bcon = d.PhysicalData.bcon[ species[0]].size
+        len_bcon = physical_template.bcon[ species[0]].size
         len_emis = init_guess.size - len_bcon
         # now assign zero as lower bound for emissions
         bounds = len_emis * [(0, None)]


### PR DESCRIPTION
-------

## Description
Recent analysis of posterior emissions showed that 4dvar could
generate negative scaling factors, contrary to the expectations in the
design. This change turns off negative emissions by default and allows
them to be activated via an environment variable ALLOW_NEGATIVE_EMISSIONS
## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`

## Notes