### PR TITLE
Adding archiving of first-guess simulation of observations

### DIFF
--- a/changelog/158.improvement.md
+++ b/changelog/158.improvement.md
@@ -1,0 +1,1 @@
+Adding archiving of first-guess simulation of observations

--- a/src/fourdvar/_main_driver.py
+++ b/src/fourdvar/_main_driver.py
@@ -28,7 +28,8 @@ from fourdvar.env import env
 logger = get_logger(__name__)
 
 
-def cost_func(vector):
+def cost_func(vector,
+              archive_obs_file=None):
     """framework: cost function used by minimizer
     input: numpy.ndarray
     output: scalar.
@@ -61,9 +62,9 @@ def cost_func(vector):
 
     simulated = transform(model_out, d.ObservationData)
 
-    # TODO: Temp archive for debugging
-    simulated.archive("forward-test.ncf", force_lite=True)
-    logger.warning("Forward test log complete")
+    if archive_obs_file is not None:
+        simulated.archive(archive_obs_file, force_lite=True)
+        logger.info(f"archiving simulated concentrations in {archive_obs_file}")
 
     residual = d.ObservationData.get_residual(observed, simulated)
     w_residual = d.ObservationData.error_weight(residual)

--- a/src/fourdvar/_main_driver.py
+++ b/src/fourdvar/_main_driver.py
@@ -56,9 +56,6 @@ def cost_func(vector,
         model_out = transform(model_in, d.ModelOutputData)
         data_access.prev_vector = vector.copy()
 
-    # TODO: Temp archive for debugging
-    model_out.archive("conc_cost.ncf")
-    logger.warning("Archived concentrations in cost function")
 
     simulated = transform(model_out, d.ObservationData)
 
@@ -132,9 +129,6 @@ def gradient_func(vector):
 
     simulated = transform(model_out, d.ObservationData)
 
-    # TODO: Temp archive for debugging
-    simulated.archive("forward-test.ncf", force_lite=True)
-    logger.warning("Forward test log complete")
 
     residual = d.ObservationData.get_residual(observed, simulated)
     w_residual = d.ObservationData.error_weight(residual)

--- a/src/fourdvar/user_driver.py
+++ b/src/fourdvar/user_driver.py
@@ -117,7 +117,7 @@ def minim(cost_func, grad_func,
     # turn on skipping of unneeded fwd calls
     data_access.allow_fwd_skip = True
 
-    start_cost = cost_func(init_guess)
+    start_cost = cost_func(init_guess, archive_obs_file="simulobs_first_guess.pic.gz")
     start_grad = grad_func(init_guess)
     start_dict = {"start_cost": start_cost, "start_grad": start_grad}
 

--- a/src/fourdvar/user_driver.py
+++ b/src/fourdvar/user_driver.py
@@ -97,7 +97,6 @@ def callback_func(current_vector):
     current_physical.archive(f"iter{iter_num:04}.ncf")
     if archive_defn.iter_model_output is True:
         current_model_output = d.ModelOutputData()
-        current_model_output.archive(f"conc_iter{iter_num:04}.ncf")
     if archive_defn.iter_obs_lite is True:
         current_model_output = d.ModelOutputData()
         current_obs = transform(current_model_output, d.ObservationData)


### PR DESCRIPTION
-------

## Description
A critical diagnostic for understanding posterior emissions is the
difference between the simulation using prior emissions and the
observations. This PR archives the so-called first-guess simulations
on the first run of the forward model. 
## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes