### PR TITLE
switching to daily varying BCs and changing uncertainty accordingly

### DIFF
--- a/changelog/161.improvement.md
+++ b/changelog/161.improvement.md
@@ -1,0 +1,1 @@
+change to daily boundary conditions and increase uncertainty accordingly

--- a/scripts/cmaq_preprocess/make_prior.py
+++ b/scripts/cmaq_preprocess/make_prior.py
@@ -65,7 +65,7 @@ def make_prior(save_path: str, emis_template: str) -> None:
     # 'emis' to use timestep from emissions file
     # 'single' for using a single average across the entire model run
     # integer to use custom number of seconds
-    bcon_tsec = "single"
+    bcon_tsec = 24*60*60 # one day
 
     # data for emission uncertainty
     # allowed values:
@@ -87,7 +87,7 @@ def make_prior(save_path: str, emis_template: str) -> None:
     # dict: apply single value to each spcs ( eg: { 'CO2':1e-6, 'CO':1e-7 } )
     # string: filename for netCDF file already correctly formatted.
     # for test case using 50ppb/day CO
-    bcon_unc = {"CH4": 1e-9}  # ppm/s
+    bcon_unc = {"CH4": 5e-9}  # ppm/s
 
     # convert spc_list into valid list
     emissions_filename = dt.replace_date(emis_template, date_defn.start_date)

--- a/scripts/cmaq_preprocess/make_prior.py
+++ b/scripts/cmaq_preprocess/make_prior.py
@@ -87,7 +87,7 @@ def make_prior(save_path: str, emis_template: str) -> None:
     # dict: apply single value to each spcs ( eg: { 'CO2':1e-6, 'CO':1e-7 } )
     # string: filename for netCDF file already correctly formatted.
     # for test case using 50ppb/day CO
-    bcon_unc = {"CH4": 5e-9}  # ppm/s
+    bcon_unc = {"CH4": 5e-7}  # ppm/s
 
     # convert spc_list into valid list
     emissions_filename = dt.replace_date(emis_template, date_defn.start_date)


### PR DESCRIPTION
-------

## Description
This changes boundary condition corrections so they can change each
day. We also multiply the daily uncertainty by a factor 5 since the
repeated independent values of the daily BCs will reduce the
uncertainty on the monthly average by 1/sqrt(n) where there are n days
in a month. This responds to #160
## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes