### PR TITLE
Fix do_ICs codepath incorrectly referencing ncoutb

### DIFF
--- a/src/cmaq_preprocess/cams.py
+++ b/src/cmaq_preprocess/cams.py
@@ -283,7 +283,7 @@ def interpolate_from_cams_to_cmaq_grid(
             if do_ICs:
                 print("write ICs to file: ", outICON)
                 ncouti = netCDF4.Dataset(outICON, "r+", format="NETCDF4")
-                all_vars = list(ncoutb.variables.keys())[1:]
+                all_vars = list(ncouti.variables.keys())[1:]
                 nvars = len(all_vars)
 
             lens = dict()


### PR DESCRIPTION

## Description

Resolves #164 .

ncoutb will only exist if do_BCs is true, which is not necessarily the case in this block. This seems likely to be a copy/paste error, although it's odd that it wasn't caught until now. If do_BCs and do_ICs are both true, would this cause a bug with the initial conditions?

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`

## Notes
