### PR TITLE
adding bias correction for emissions

### DIFF
--- a/scripts/cmaq_preprocess/bias_correct_cams.py
+++ b/scripts/cmaq_preprocess/bias_correct_cams.py
@@ -4,10 +4,11 @@ import xarray as xr
 
 import fourdvar.params.input_defn
 from cmaq_preprocess.bias import (
-    calculate_bias,
+    calculate_icon_bias,
+    calculate_emissions_bias,
     correct_icon_bcon,
     get_bcon_files,
-    get_icon_file,
+    get_icon_files,
     get_met_file,
 )
 from cmaq_preprocess.read_config_cmaq import load_config_from_env
@@ -16,26 +17,32 @@ from cmaq_preprocess.read_config_cmaq import load_config_from_env
 def main():
     """Correct the bias between the iCon mean and the satellite observation mean."""
     config = load_config_from_env()
-    icon_file = get_icon_file(config)
+    icon_files = get_icon_files(config)
     bcon_files = get_bcon_files(config)
     met_file = get_met_file(config)
     correct_bias_by_region = os.getenv("DISABLE_CORRECT_BIAS_BY_REGION") != "true"
     levels = xr.open_dataset(met_file).attrs["VGLVLS"]
-    bias = calculate_bias(
-        icon_file=icon_file,
+    icon_bias = calculate_icon_bias(
+        icon_files=icon_files, 
         obs_file=fourdvar.params.input_defn.obs_file,
         levels=levels,
         start_date=config.start_date,
         end_date=config.end_date,
         correct_bias_by_region=correct_bias_by_region,
     )
+    print(f"icon_bias={icon_bias:f}")
+    emissions_bias = calculate_emissions_bias(
+        start_date=config.start_date,
+        end_date=config.end_date,
+    )
+    print(f"emissions_bias={emissions_bias:f}")
+    total_bias = icon_bias + emissions_bias
 
-    print(f"{bias=}")
 
     correct_icon_bcon(
         species="CH4",
-        bias=bias,
-        icon_file=icon_file,
+        bias=total_bias,
+        icon_files=[icon_files[0]],
         bcon_files=bcon_files,
     )
 

--- a/scripts/cmaq_preprocess/bias_correct_cams.py
+++ b/scripts/cmaq_preprocess/bias_correct_cams.py
@@ -17,6 +17,7 @@ from cmaq_preprocess.read_config_cmaq import load_config_from_env
 def main():
     """Correct the bias between the iCon mean and the satellite observation mean."""
     config = load_config_from_env()
+    species = "CH4"
     icon_files = get_icon_files(config)
     bcon_files = get_bcon_files(config)
     met_file = get_met_file(config)
@@ -31,16 +32,15 @@ def main():
         correct_bias_by_region=correct_bias_by_region,
     )
     print(f"icon_bias={icon_bias:f}")
-    emissions_bias = calculate_emissions_bias(
-        start_date=config.start_date,
-        end_date=config.end_date,
-    )
+    emissions_bias = calculate_emissions_bias( prior_file = fourdvar.params.input_defn.prior_file,
+                                               obs_file = fourdvar.params.input_defn.obs_file,
+                                               species=species)
     print(f"emissions_bias={emissions_bias:f}")
-    total_bias = icon_bias + emissions_bias
+    total_bias = icon_bias - emissions_bias
 
 
     correct_icon_bcon(
-        species="CH4",
+        species=species,
         bias=total_bias,
         icon_files=[icon_files[0]],
         bcon_files=bcon_files,

--- a/scripts/cmaq_preprocess/bias_correct_cams.py
+++ b/scripts/cmaq_preprocess/bias_correct_cams.py
@@ -12,7 +12,9 @@ from cmaq_preprocess.bias import (
     get_met_file,
 )
 from cmaq_preprocess.read_config_cmaq import load_config_from_env
+from util.logger import get_logger
 
+logger = get_logger(__name__)
 
 def main():
     """Correct the bias between the iCon mean and the satellite observation mean."""
@@ -31,11 +33,11 @@ def main():
         end_date=config.end_date,
         correct_bias_by_region=correct_bias_by_region,
     )
-    print(f"icon_bias={icon_bias:f}")
+    logger.debug(f"icon_bias={icon_bias:f}")
     emissions_bias = calculate_emissions_bias( prior_file = fourdvar.params.input_defn.prior_file,
                                                obs_file = fourdvar.params.input_defn.obs_file,
                                                species=species)
-    print(f"emissions_bias={emissions_bias:f}")
+    logger.debug(f"emissions_bias={emissions_bias:f}")
     total_bias = icon_bias - emissions_bias
 
 

--- a/src/cmaq_preprocess/bias.py
+++ b/src/cmaq_preprocess/bias.py
@@ -16,6 +16,9 @@ import fourdvar.datadef as d
 from fourdvar._transform import transform
 from fourdvar.params.input_defn import obs_file, prior_file
 from fourdvar.params.root_path_defn import store_path
+from util.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 def mass_weighted_mean(
@@ -28,7 +31,7 @@ def mass_weighted_mean(
     returns three-dimensional thickness-weighted mean of species from netcdf file filename
     in ppm
     """
-    print("file name",file_name)
+    logger.debug(f"file name: {file_name}")
     with xr.open_dataset(file_name) as ds:
         field = ds[species].to_numpy()
         vertical_integral = np.tensordot(field, thickness, (-3, 0)).squeeze()
@@ -38,7 +41,7 @@ def mass_weighted_mean(
             ]
         else:
             region_slice = np.s_[:, :]  # whole array
-        print("region slice", region_slice, vertical_integral[region_slice].mean())
+        logger.info(f"region slice, {region_slice} with mean: {vertical_integral[region_slice].mean()}")
         return vertical_integral[region_slice].mean()
 
 
@@ -129,8 +132,8 @@ def calculate_icon_bias(
             icon_means.append( icon_mass_weighted_mean)
     icon_means = np.array(icon_means)
     obs_means = np.array(obs_means)
-    print('icon_means',icon_means)
-    print('obs_means',obs_means)
+    logger.info(f"icon_means: {icon_means}")
+    logger.info(f"obs_means: {obs_means}")
     obs_means /= 1000. # from ppb to ppm
     return obs_means.mean() - icon_means.mean()
 

--- a/src/cmaq_preprocess/bias.py
+++ b/src/cmaq_preprocess/bias.py
@@ -24,6 +24,7 @@ def mass_weighted_mean(
     returns three-dimensional thickness-weighted mean of species from netcdf file filename
     in ppm
     """
+    print("file name",file_name)
     with xr.open_dataset(file_name) as ds:
         field = ds[species].to_numpy()
         vertical_integral = np.tensordot(field, thickness, (-3, 0)).squeeze()
@@ -37,57 +38,14 @@ def mass_weighted_mean(
         return vertical_integral[region_slice].mean()
 
 
-def earliest_observation_date(
-    start_date: datetime.date,
-    end_date: datetime.date,
-    obs: ObservationData,
-) -> datetime.datetime:
-    """
-    takes an observation dataset and returns the first day with observations
-    """
-    one_day = datetime.timedelta(days=1)
-    date = start_date
-    while date <= end_date:
-        date_string = date.strftime("%Y%m%d")
-        if len(obs.ind_by_date[date_string]) > 0:
-            return date
-        else:
-            date += one_day
-    return None
-
-
-def earliest_mean(
-    start_date: datetime.date,
-    end_date: datetime.date,
-    obs_file: pathlib.Path,
-) -> float:
-    obs = ObservationData.from_file(obs_file)
-    earliest_date = earliest_observation_date(start_date, end_date, obs)
-    if earliest_date is None:
-        raise ValueError("no valid observations found")
-    date_string = earliest_date.strftime("%Y%m%d")
-    return np.mean(np.array(obs.value)[obs.ind_by_date[date_string]])
-
-
-def earliest_region(
-    start_date: datetime.date,
-    end_date: datetime.date,
-    obs_file: pathlib.Path,
-) -> tuple:
-    obs = ObservationData.from_file(obs_file)
-    earliest_date = earliest_observation_date(start_date, end_date, obs)
-    if earliest_date is None:
-        raise ValueError("no valid observations found")
-    date_string = earliest_date.strftime("%Y%m%d")
-    lite_coords = [obs.lite_coord[d] for d in obs.ind_by_date[date_string]]
-    llc_inds = (np.min([l[3] for l in lite_coords]), np.min([l[4] for l in lite_coords]))
-    urc_inds = (np.max([l[3] for l in lite_coords]), np.max([l[4] for l in lite_coords]))
-    return llc_inds, urc_inds
-
-
-def get_icon_file(config: CMAQConfig) -> pathlib.Path:
-    chem_dir = utils.nested_dir(config.domain, config.start_date, config.ctm_dir)
-    return chem_dir / f"ICON.{config.domain.id}.{config.domain.mcip_suffix}.{config.mech}.nc"
+def get_icon_files(config: CMAQConfig) -> list[pathlib.Path]:
+    icon_files = []
+    for date in utils.date_range(config.start_date, config.end_date):
+        chem_dir = utils.nested_dir(config.domain, date, config.ctm_dir)
+        icon_files.append(
+            chem_dir / f"ICON.{config.domain.id}.{config.domain.mcip_suffix}.{config.mech}.nc"
+        )
+    return icon_files
 
 
 def get_bcon_files(config: CMAQConfig) -> list[pathlib.Path]:
@@ -105,13 +63,24 @@ def get_met_file(config: CMAQConfig) -> pathlib.Path:
     return met_dir / f"METCRO3D_{config.domain.mcip_suffix}"
 
 
+def get_region(obs: ObservationData,
+               date: datetime.date,
+               ) -> tuple:
+    date_string = date.strftime("%Y%m%d")
+    lite_coords = [obs.lite_coord[d] for d in obs.ind_by_date[date_string]]
+    llc_inds = (np.min([l[3] for l in lite_coords]), np.min([l[4] for l in lite_coords]))
+    urc_inds = (np.max([l[3] for l in lite_coords]), np.max([l[4] for l in lite_coords]))
+    return llc_inds, urc_inds
+
+
+
 def correct_icon_bcon(
     species: str,
     bias: float,
-    icon_file: pathlib.Path,
+    icon_files: list[pathlib.Path],
     bcon_files: list[pathlib.Path],
 ):
-    all_files = [*bcon_files, icon_file]
+    all_files = [*bcon_files, *icon_files]
     temp_file_name = "temp.nc"
     for file in all_files:
         with xr.open_dataset(file) as ds:
@@ -121,29 +90,48 @@ def correct_icon_bcon(
             shutil.move(temp_file_name, file)
 
 
-def calculate_bias(
+def calculate_icon_bias(
     start_date: datetime.date,
     end_date: datetime.date,
-    icon_file: pathlib.Path,
+    icon_files: list[pathlib.Path],
     obs_file: pathlib.Path,
     levels: np.ndarray[float],
     correct_bias_by_region: bool = False,
 ) -> float:
-    """Calculates the bias between iCon mean and satellite mean on the first day.
+    """Calculates the bias between iCon mean and satellite mean across the month.
 
     The bias is returned in units of ppm, with positive numbers meaning the satellite
     mean is higher.
     If correct_bias_by_region is True the correction is based on the spatial
-    extent of TROPOMI observations on the first day, otherwise it uses the entire domain
+    extent of TROPOMI observations on each day, otherwise it uses the entire domain
     """
     thickness = levels[:-1] - levels[1:]
-    satellite_mean_first_day = earliest_mean(
-        obs_file=obs_file, start_date=start_date, end_date=end_date
-    )
-    satellite_mean_first_day /= 1000.0  # ppb to ppm
-    if correct_bias_by_region:
-        region_inds = earliest_region(obs_file=obs_file, start_date=start_date, end_date=end_date)
-    else:
-        region_inds = None
-    icon_mass_weighted_mean = mass_weighted_mean(icon_file, "CH4", thickness, region_inds)
-    return satellite_mean_first_day - icon_mass_weighted_mean
+    obs = ObservationData.from_file(obs_file)
+    icon_means = []
+    obs_means = []
+    for i_date, date in enumerate(utils.date_range( start_date, end_date)):
+        date_string = date.strftime("%Y%m%d")
+        if len(obs.ind_by_date[date_string]) > 0:
+            obs_means.append(np.mean(np.array(
+                obs.value)[obs.ind_by_date[date_string]]))
+            if correct_bias_by_region:
+                region_inds = get_region(obs=obs, date=date)
+            else:
+                region_inds = None
+            icon_mass_weighted_mean = mass_weighted_mean(icon_files[i_date],
+                                                         "CH4", thickness,
+                                                         region_inds)
+            icon_means.append( icon_mass_weighted_mean)
+    icon_means = np.array(icon_means)
+    obs_means = np.array(obs_means)
+    print('icon_means',icon_means)
+    print('obs_means',obs_means)
+    obs_means /= 1000. # from ppb to ppm
+    return obs_means.mean() - icon_means.mean()
+
+
+def calculate_emissions_bias(
+        start_date: datetime.date,
+        end_date: datetime.date,
+        ) -> float:
+    return 0.0

--- a/tests/unit/cmaq_preprocess/test_bias_correct_cams.py
+++ b/tests/unit/cmaq_preprocess/test_bias_correct_cams.py
@@ -48,7 +48,7 @@ def test_bias_zero_after_correct(test_data_dir, tmp_path, monkeypatch, metcro3d_
     cmaq_preprocess.bias.correct_icon_bcon(
         species="CH4",
         bias=bias,
-        icon_file=icon_file,
+        icon_files=[icon_file],
         bcon_files=bcon_files,
     )
 

--- a/tests/unit/cmaq_preprocess/test_bias_correct_cams.py
+++ b/tests/unit/cmaq_preprocess/test_bias_correct_cams.py
@@ -32,8 +32,8 @@ def test_bias_zero_after_correct(test_data_dir, tmp_path, monkeypatch, metcro3d_
     levels = xr.open_dataset(metcro3d_file).attrs["VGLVLS"]
 
     # calculate bias
-    bias = cmaq_preprocess.bias.calculate_bias(
-        icon_file=icon_file,
+    bias = cmaq_preprocess.bias.calculate_icon_bias(
+        icon_files=[icon_file],
         obs_file=obs_file,
         levels=levels,
         start_date=start_date,

--- a/tests/unit/cmaq_preprocess/test_bias_correct_cams.py
+++ b/tests/unit/cmaq_preprocess/test_bias_correct_cams.py
@@ -53,8 +53,8 @@ def test_bias_zero_after_correct(test_data_dir, tmp_path, monkeypatch, metcro3d_
     )
 
     # calculate new bias - should be zero
-    new_bias = cmaq_preprocess.bias.calculate_bias(
-        icon_file=icon_file,
+    new_bias = cmaq_preprocess.bias.calculate_icon_bias(
+        icon_files=[icon_file],
         obs_file=obs_file,
         levels=levels,
         start_date=start_date,


### PR DESCRIPTION
## Description
This change responds to #163
## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`

## Notes
The algorithm is described in #163. We add parallel runs with and
without emissions and correct the bias correction accordingly. The
science weakness here is that the first guess field is unbiased WRT
the TROPOMI obs by construction. This foregoes the ability of the
observations to comment on the overall emissions via the  average
concentration
though corrections to local emissions will still hold.