### PR TITLE
Add prior sectors to posterior emissions output

### DIFF
--- a/changelog/169.improvement.md
+++ b/changelog/169.improvement.md
@@ -1,0 +1,1 @@
+Add prior sector estimates to posterior output file

--- a/tests/integration/postproc/test_posterior_emissions_postprocess.py
+++ b/tests/integration/postproc/test_posterior_emissions_postprocess.py
@@ -135,6 +135,14 @@ def test_posterior_emissions_postprocess(target_environment, test_data_dir):
         148.8186
     ), "lon coordinates do not match expected"
 
+    # check that prior emissions in the posterior output are the mean of all
+    # prior timesteps from the input
+    prior_sector_vars = [var_name for var_name in prior_emissions.variables if var_name.startswith("ch4_sector")]
+    for sector_var in prior_sector_vars:
+        sector_mean = prior_emissions[sector_var].mean(axis=0)
+        # spot check a single coord at 1,1
+        assert float(sector_mean[0, 1, 1]) == float(posterior_emissions[f"prior_{sector_var}"][0, 0, 1, 1])
+
 
 def test_posterior_emissions_postprocess_multi_day(target_environment, test_data_dir):
     target_environment("docker-test")
@@ -174,3 +182,6 @@ def test_posterior_emissions_postprocess_multi_day(target_environment, test_data
     assert posterior_emissions["time_bounds"][0][1] == np.datetime64(
         "2022-07-24"
     ), "time_bounds do not match expected"
+
+    # TODO: check that sectoral ch4 variables equal the mean of all time steps
+    # in the prior file, when we have a multi-day prior for tests


### PR DESCRIPTION
## Description

Adding the sector averages over the time period where the posterior estimates were generated will help us with analysis and sectoral attribution in the future. Since the prior emissions are in daily time steps, they must be averaged across the entire period so that the data and coordinates align with the posterior and prior monthly estimate.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
