### PR TITLE
Fetch domain file when loading files for a daily workflow run

### DIFF
--- a/changelog/176.improvement.md
+++ b/changelog/176.improvement.md
@@ -1,0 +1,1 @@
+Fetch domain file in load_from_archive.py for daily workflow

--- a/scripts/alerts/alerts_baseline.py
+++ b/scripts/alerts/alerts_baseline.py
@@ -21,7 +21,7 @@ from postproc import alerts
 
 
 def main():
-    domain_file = env.path("ALERTS_DOMAIN_FILE")
+    domain_file = env.path("DOMAIN_FILE")
     dir_glob = env.str("ALERTS_BASELINE_DIRS", default=None)
     dir_list = sorted(glob.glob(dir_glob))
     if dir_list is None:

--- a/scripts/docker-e2e-daily.sh
+++ b/scripts/docker-e2e-daily.sh
@@ -25,6 +25,8 @@ DATA_PATH="$DATA_ROOT/$RUN_ID"
 STORE_PATH="/opt/project/data/$RUN_ID"
 CHK_PATH="$STORE_PATH/scratch"
 
+DOMAIN_FILE="$STORE_PATH/domain.$DOMAIN_NAME.nc"
+
 TARGET_BUCKET="s3://om-dev-results"
 #TARGET_BUCKET_REDUCED="s3://om-dev-output" # WARNING: THIS WILL OVERWRITE FILES IN s3
 TARGET_BUCKET_REDUCED=""
@@ -58,6 +60,7 @@ START_DATE=$START_DATE
 END_DATE=$END_DATE
 DOMAIN_NAME=$DOMAIN_NAME
 DOMAIN_VERSION=$DOMAIN_VERSION
+DOMAIN_FILE=$DOMAIN_FILE
 STORE_PATH=$STORE_PATH
 CHK_PATH=$CHK_PATH
 NCPUS=$NCPUS
@@ -80,6 +83,12 @@ echo "Running om-daily end-to-end, data will be stored in $DATA_PATH"
 #  -e AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" \
 #  -e AWS_REGION="$AWS_REGION" \
 #  openmethane python scripts/load_from_archive.py --sync daily
+
+# fetch the domain file from the data store
+if [[ ! -f "$DATA_PATH/domain.$DOMAIN_NAME.nc" ]]; then
+  curl -s -o "$DATA_PATH/domain.$DOMAIN_NAME.nc" \
+    "https://openmethane.s3.amazonaws.com/domains/$DOMAIN_NAME/$DOMAIN_VERSION/domain.$DOMAIN_NAME.nc"
+fi
 
 if [[ ! -f "$STORE_PATH/alerts-baseline.nc" ]]; then
   if [[ -f "$DATA_ROOT/monthly/$DOMAIN_NAME/$DOMAIN_VERSION/alerts-baseline.nc" ]]; then

--- a/scripts/docker-e2e-monthly.sh
+++ b/scripts/docker-e2e-monthly.sh
@@ -25,6 +25,8 @@ DATA_PATH="$DATA_ROOT/$RUN_ID"
 STORE_PATH="/opt/project/data/$RUN_ID"
 CHK_PATH="$STORE_PATH/scratch"
 
+DOMAIN_FILE="$STORE_PATH/domain.$DOMAIN_NAME.nc"
+
 TARGET_BUCKET="s3://om-dev-results"
 
 if [[ -f .env ]]; then
@@ -50,6 +52,7 @@ START_DATE=$START_DATE
 END_DATE=$END_DATE
 DOMAIN_NAME=$DOMAIN_NAME
 DOMAIN_VERSION=$DOMAIN_VERSION
+DOMAIN_FILE=$DOMAIN_FILE
 STORE_PATH=$STORE_PATH
 CHK_PATH=$CHK_PATH
 NCPUS=$NCPUS
@@ -71,6 +74,12 @@ echo "Running om-monthly end-to-end, data will be stored in $DATA_PATH"
 #  -e AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" \
 #  -e AWS_REGION="$AWS_REGION" \
 #  openmethane python scripts/load_from_archive.py --sync monthly
+
+# fetch the domain file from the data store
+if [[ ! -f "$DATA_PATH/domain.$DOMAIN_NAME.nc" ]]; then
+  curl -s -o "$DATA_PATH/domain.$DOMAIN_NAME.nc" \
+    "https://openmethane.s3.amazonaws.com/domains/$DOMAIN_NAME/$DOMAIN_VERSION/domain.$DOMAIN_NAME.nc"
+fi
 
 # Local alternative to archive-load which just copies/links the files
 COPY_TIMESTAMP=$(date -d "$START_DATE")

--- a/scripts/docker-e2e-monthly.sh
+++ b/scripts/docker-e2e-monthly.sh
@@ -144,7 +144,6 @@ docker run --name="e2e-monthly-fourdvar-monthly" --rm \
 # JobName: alerts-baseline
 docker run --name="e2e-monthly-alerts-baseline" --rm \
   --env-file "$ENV_FILE" -v "$DATA_ROOT":/opt/project/data \
-  -e ALERTS_DOMAIN_FILE="$STORE_PATH/prior/outputs/prior-emissions.nc" \
   -e ALERTS_BASELINE_DIRS="$STORE_PATH/$DOMAIN_NAME/daily/*/*/*" \
   -e ALERTS_BASELINE_FILE="$STORE_PATH/alerts-baseline.nc" \
   openmethane python scripts/alerts/alerts_baseline.py

--- a/scripts/load_from_archive.py
+++ b/scripts/load_from_archive.py
@@ -45,8 +45,10 @@ def load_from_archive(sync: str = "monthly"):
         case "daily":
             archive.daily(
                 daily_s3_bucket=ARCHIVE_BUCKET,
+                public_s3_bucket=PUBLIC_BUCKET,
                 start_date=START_DATE,
                 domain_name=DOMAIN_NAME,
+                domain_version=DOMAIN_VERSION,
                 local_path=STORE_PATH,
                 alerts_baseline_remote=ALERTS_BASELINE_REMOTE,
             )

--- a/src/util/archive.py
+++ b/src/util/archive.py
@@ -53,8 +53,10 @@ def monthly(
 
 def daily(
     daily_s3_bucket: str,
+    public_s3_bucket: str,
     start_date: datetime.date,
     domain_name: str,
+    domain_version: str,
     local_path: pathlib.Path,
     alerts_baseline_remote: pathlib.Path,
 ):
@@ -64,6 +66,8 @@ def daily(
     on the same day to skip expensive re-processing for data that isn't
     likely to change.
     """
+    fetch_domain(public_s3_bucket, domain_name, domain_version, local_path)
+
     daily_root = _get_daily_archive_path(daily_s3_bucket, domain_name, start_date)
 
     for remote_path in [

--- a/tests/unit/util/test_archive.py
+++ b/tests/unit/util/test_archive.py
@@ -59,11 +59,24 @@ def test_daily(mockRun, tmp_path):
     # initiate load archive for a daily run
     daily(
         "test-bucket-name",
+        "test-public-bucket",
         datetime.date(2022, 10, 29),
         "test-domain",
+        "v2",
         tmp_path,
         pathlib.Path("alerts-baseline.nc"),
     )
+
+    # fetch the domain file
+    mockRun.assert_has_calls([
+        call([
+            "aws", "s3", "ls", "s3://test-public-bucket/domains/test-domain/v2/domain.test-domain.nc",
+        ], check=True, capture_output=False),
+        call([
+            "aws", "s3", "cp", "--no-progress", "s3://test-public-bucket/domains/test-domain/v2/domain.test-domain.nc",
+            str(tmp_path),
+        ], check=True, capture_output=True, text=True),
+    ])
 
     # daily run will fetch wrf and mcip folders for each day
     for path in ['wrf', 'mcip']:


### PR DESCRIPTION
## Description

This brings the daily workflow in line with monthly and baseline workflows where the domain file is always fetched, and made available via the `DOMAIN_FILE` env variable.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes

This change has been verified in a 2-day daily/monthly run in the sandbox environment:

```
984e8cee-c2cc-4928-8661-e2cce098815b  2025-08-31 09:44  0:32:37.710000           SUCCEEDED
```
