### PR TITLE
Fix "patch" bump adding an extra increment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,8 +48,12 @@ jobs:
       - name: Determine release version
         id: release-version
         run: |
+          BUMP="${{ github.event.inputs.bump_rule }}"
+          # patch is already bumped for pre-release, "stable" will remove "dev"
+          [[ $BUMP == "patch" ]] && BUMP="stable"
+          
           BASE_VERSION=`uv version --short`
-          NEW_VERSION=`uv version --short --bump ${{ github.event.inputs.bump_rule }}`
+          NEW_VERSION=`uv version --short --bump $BUMP`
           echo "BASE_VERSION=$BASE_VERSION" >> $GITHUB_ENV
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
           echo "RELEASE_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT

--- a/changelog/193.fix.md
+++ b/changelog/193.fix.md
@@ -1,0 +1,1 @@
+Fix "patch" version bump adding an extra increment during release


### PR DESCRIPTION
## Description

Immediately after a release is created, we bump the version with a "patch"+"dev" bump, i.e. 1.0.0 to 1.0.1.dev1. If the next version is a "patch" release, we want to release 1.0.1, however the current behaviour will release 1.0.2 if "patch" is selected.

This change will use a "stable" bump to go from 1.0.1.dev1 to 1.0.1 when the desired release is a "patch".

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
