### PR TITLE
Better default experiment and archive names

### DIFF
--- a/changelog/195.improvement.md
+++ b/changelog/195.improvement.md
@@ -1,0 +1,1 @@
+Change default output folder to "archive/openmethane" from "archive_Pert/202207_test"

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -10,7 +10,7 @@ The following environment variables are configurable:
 | START_DATE         | date | Start date of the run                                              | 2022-07-01                                 |
 | END_DATE           | date | End date of the run (inclusive)                                    | 2022-07-30                                 |
 | STORE_PATH         | str  | Full path to the branch-specific data.                             | N/A                                        |          
-| EXPERIMENT         | str  | Name of the experiment being run                                   | 202207_test                                |
+| EXPERIMENT         | str  | Name of the experiment being run                                   | openmethane                                |
 | TEMPLATE_DIR       | str  | Path to the CMAQ template directory                                | {STORE_PATH}/templates                     |
 | CMAQ_SOURCE_DIR    | str  | Path to the root of the CMAQ source directory                      | N/A                                        |
 | MCIP_SOURCE_DIR    | str  | Path to the root MCIP source directory                             | N/A                                        |

--- a/scripts/fourdvar/archive_cmaq_input.py
+++ b/scripts/fourdvar/archive_cmaq_input.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from openmethane import fourdvar.datadef as d
+from openmethane.fourdvar import datadef as d
 from openmethane.fourdvar.params import archive_defn
 from openmethane.fourdvar.util import archive_handle
 

--- a/scripts/run-all.sh
+++ b/scripts/run-all.sh
@@ -41,4 +41,4 @@ python runscript.py
 
 echo "Complete"
 
-tree ${STORE_PATH}/archive_Pert
+tree ${STORE_PATH}/archive

--- a/src/openmethane/fourdvar/params/archive_defn.py
+++ b/src/openmethane/fourdvar/params/archive_defn.py
@@ -22,8 +22,8 @@ from openmethane.fourdvar.params.root_path_defn import store_path
 # Settings for archive processes
 
 # location of archive directory
-# archive_path = os.path.join( store_path, 'archive' )
-archive_path = os.path.join(store_path, "archive_Pert")  # archive_Pert
+archive_path = os.path.join(store_path, 'archive' )
+
 # archive model output of each successful iteration
 iter_model_output = True
 
@@ -31,16 +31,14 @@ iter_model_output = True
 iter_obs_lite = True
 
 # experiment name & name of directory to save results in
-# experiment = 'pert_pert_test'##'example_experiment'
-# experiment = 'real_test'
-experiment = env.str("EXPERIMENT", "202207_test")
+experiment = env.str("EXPERIMENT", "openmethane")
 
 # description is copied into a txt file in the experiment directory
 description = """This is a test of the fourdvar system.
 The description here should contain details of the experiment
 and is written to the description text file."""
 # name of txt file holding the description, if empty string ('') file is not created.
-desc_name = "description.txt"
+desc_name = ""
 
 # if True, delete any existing archive with the same name.
 # if False, create a new archive name to save results into.

--- a/tests/unit/fourdvar/test_params/test_archive_defn_docker_.yml
+++ b/tests/unit/fourdvar/test_params/test_archive_defn_docker_.yml
@@ -1,13 +1,13 @@
-archive_path: /opt/project/data/archive_Pert
+archive_path: /opt/project/data/archive
 conc_file: conc.<YYYYMMDD>.nc
-desc_name: description.txt
+desc_name: ''
 description: 'This is a test of the fourdvar system.
 
   The description here should contain details of the experiment
 
   and is written to the description text file.'
 emis_file: emis.<YYYYMMDD>.nc
-experiment: 202207_test
+experiment: openmethane
 extension: <E>_vsn<I>
 force_file: force.<YYYYMMDD>.nc
 icon_file: icon.nc

--- a/tests/unit/fourdvar/test_params/test_archive_defn_nci_.yml
+++ b/tests/unit/fourdvar/test_params/test_archive_defn_nci_.yml
@@ -1,13 +1,13 @@
-archive_path: '{HOME}/scratch/openmethane-beta/run-py4dvar/archive_Pert'
+archive_path: '{HOME}/scratch/openmethane-beta/run-py4dvar/archive'
 conc_file: conc.<YYYYMMDD>.nc
-desc_name: description.txt
+desc_name: ''
 description: 'This is a test of the fourdvar system.
 
   The description here should contain details of the experiment
 
   and is written to the description text file.'
 emis_file: emis.<YYYYMMDD>.nc
-experiment: 202207_test
+experiment: openmethane
 extension: <E>_vsn<I>
 force_file: force.<YYYYMMDD>.nc
 icon_file: icon.nc


### PR DESCRIPTION
## Description

Previous developers of fourdvar changed the default archive and experiment folder names for their current experiment, and may have committed the changes by default. This led to the default output folder for fourdvar to be `STORE_PATH/archive_Pert/202207_test`, a confusing and non-obvious location.

This change restores the previous default archive folder to "archive", and provides a default experiment name "openmethane", so fourdvar output locations will now look more like:

- `STORE_PATH/archive/openmethane`
- `STORE_PATH/archive/openmethane_vsn1`
- `STORE_PATH/archive/openmethane_vsn2`

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
