### PR TITLE
Test zenodo forward adjoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # Then, use a final image without uv for our runtime environment
 # https://github.com/openmethane/CMAQ-Adjoint
-FROM ghcr.io/openmethane/cmaq-adjoint:1.0.1
+FROM ghcr.io/openmethane/cmaq-adjoint:pr-14
 
 # These will be overwritten in GHA due to https://github.com/docker/metadata-action/issues/295
 # These must be duplicated in .github/workflows/build_docker.yaml


### PR DESCRIPTION

## Description

Build docker image from [CMAQ-Adjoint PR #14](https://github.com/openmethane/CMAQ-Adjoint/pull/14) to test zenodo forward adjoint against the results from the CU repo forward adjoint.


> [!WARNING]
> Do not merge. This PR is only intended to build an image that can be used in tests in sandbox.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`

## Notes
